### PR TITLE
feat: add Sentry observability, fix mTLS fetch, deduplicate supergraph polling

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -55,6 +55,9 @@ spec:
               value: '30000'
             - name: CERT_DIR
               value: /etc/graphql-gateway/serving-certs
+          envFrom:
+            - secretRef:
+                name: graphql-gateway
           volumeMounts:
             - name: milo-control-plane-kubeconfig
               mountPath: /etc/milo-control-plane/config

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@omnigraph/openapi": "^0.109.23",
         "@opentelemetry/context-async-hooks": "^2.4.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",
+        "@sentry/node": "^8",
         "yaml": "^2.3.2"
       },
       "devDependencies": {
@@ -5110,6 +5111,102 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.0.tgz",
+      "integrity": "sha512-aTUWbzbFMFeRODn3720TZO0tsh/49T8H3h8vVnVKJ+yE36AeW38Uj/8zykQ/9nO8Vrtjr5yKuX3uMiG/W8FKNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-restify": {
       "version": "0.54.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.54.0.tgz",
@@ -5588,6 +5685,144 @@
         "@opentelemetry/api": "^1.1.0"
       }
     },
+    "node_modules/@prisma/instrumentation": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
+      "integrity": "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.8",
+        "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0",
+        "@opentelemetry/sdk-trace-base": "^1.22"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@prisma/instrumentation/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -5657,6 +5892,697 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
       "license": "MIT"
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
+      "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.55.0.tgz",
+      "integrity": "sha512-h10LJLDTRAzYgay60Oy7moMookqqSZSviCWkkmHZyaDn+4WURnPp5SKhhfrzPRQcXKrweiOwDSHBgn1tweDssg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/instrumentation-amqplib": "^0.46.0",
+        "@opentelemetry/instrumentation-connect": "0.43.0",
+        "@opentelemetry/instrumentation-dataloader": "0.16.0",
+        "@opentelemetry/instrumentation-express": "0.47.0",
+        "@opentelemetry/instrumentation-fastify": "0.44.1",
+        "@opentelemetry/instrumentation-fs": "0.19.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.43.0",
+        "@opentelemetry/instrumentation-graphql": "0.47.0",
+        "@opentelemetry/instrumentation-hapi": "0.45.1",
+        "@opentelemetry/instrumentation-http": "0.57.1",
+        "@opentelemetry/instrumentation-ioredis": "0.47.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.7.0",
+        "@opentelemetry/instrumentation-knex": "0.44.0",
+        "@opentelemetry/instrumentation-koa": "0.47.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.44.0",
+        "@opentelemetry/instrumentation-mongodb": "0.51.0",
+        "@opentelemetry/instrumentation-mongoose": "0.46.0",
+        "@opentelemetry/instrumentation-mysql": "0.45.0",
+        "@opentelemetry/instrumentation-mysql2": "0.45.0",
+        "@opentelemetry/instrumentation-nestjs-core": "0.44.0",
+        "@opentelemetry/instrumentation-pg": "0.50.0",
+        "@opentelemetry/instrumentation-redis-4": "0.46.0",
+        "@opentelemetry/instrumentation-tedious": "0.18.0",
+        "@opentelemetry/instrumentation-undici": "0.10.0",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@prisma/instrumentation": "5.22.0",
+        "@sentry/core": "8.55.0",
+        "@sentry/opentelemetry": "8.55.0",
+        "import-in-the-middle": "^1.11.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
+      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
+      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.46.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
+      "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.0.tgz",
+      "integrity": "sha512-Q57JGpH6T4dkYHo9tKXONgLtxzsh1ZEW5M9A/OwKrZFyEpLqWgjhcZ3hIuVvDlhb426iDF1f9FPToV/mi5rpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.36"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.0.tgz",
+      "integrity": "sha512-88+qCHZC02up8PwKHk0UQKLLqGGURzS3hFQBZC7PnGwReuoKjHXS1o29H58S+QkXJpkTr2GACbx8j6mUoGjNPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.0.tgz",
+      "integrity": "sha512-XFWVx6k0XlU8lu6cBlCa29ONtVt6ADEjmxtyAyeF2+rifk8uBJbk1La0yIVfI0DoKURGbaEDTNelaXG9l/lNNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-fastify": {
+      "version": "0.44.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.1.tgz",
+      "integrity": "sha512-RoVeMGKcNttNfXMSl6W4fsYoCAYP1vi6ZAWIGhBY+o7R9Y0afA7f9JJL0j8LHbyb0P0QhSYk+6O56OwI2k4iRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.0.tgz",
+      "integrity": "sha512-JGwmHhBkRT2G/BYNV1aGI+bBjJu4fJUD/5/Jat0EWZa2ftrLV3YE8z84Fiij/wK32oMZ88eS8DI4ecLGZhpqsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.0.tgz",
+      "integrity": "sha512-at8GceTtNxD1NfFKGAuwtqM41ot/TpcLh+YsGe4dhf7gvv1HW/ZWdq6nfRtS6UjIvZJOokViqLPJ3GVtZItAnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.0.tgz",
+      "integrity": "sha512-Cc8SMf+nLqp0fi8oAnooNEfwZWFnzMiBHCGmDFYqmgjPylyLmi83b+NiTns/rKGwlErpW0AGPt0sMpkbNlzn8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.1.tgz",
+      "integrity": "sha512-VH6mU3YqAKTePPfUPwfq4/xr049774qWtfTuJqVHoVspCLiT3bW+fCQ1toZxt6cxRPYASoYaBsMA3CWo8B8rcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.1.tgz",
+      "integrity": "sha512-ThLmzAQDs7b/tdKI3BV2+yawuF09jF111OFsovqT1Qj3D8vjwKBwhi/rDE5xethwn4tSXtZcJ9hBsVAlWFQZ7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/instrumentation": "0.57.1",
+        "@opentelemetry/semantic-conventions": "1.28.0",
+        "forwarded-parse": "2.1.2",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.1.tgz",
+      "integrity": "sha512-I4PHczeujhQAQv6ZBzqHYEUiggZL4IdSMixtVD3EYqbdrjujE7kRfI5QohjlPoJm8BvenoW5YaTMWRrbpot6tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.57.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.1.tgz",
+      "integrity": "sha512-SgHEKXoVxOjc20ZYusPG3Fh+RLIZTSa4x8QtD3NfgAUDyqdFFS9W1F2ZVbZkqDCdyMcQG02Ok4duUGLHJXHgbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.1",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.0.tgz",
+      "integrity": "sha512-4HqP9IBC8e7pW9p90P3q4ox0XlbLGme65YTrA3UTLvqvo4Z6b0puqZQP203YFu8m9rE/luLfaG7/xrwwqMUpJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/redis-common": "^0.36.2",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.0.tgz",
+      "integrity": "sha512-LB+3xiNzc034zHfCtgs4ITWhq6Xvdo8bsq7amR058jZlf2aXXDrN9SV4si4z2ya9QX4tz6r4eZJwDkXOp14/AQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.0.tgz",
+      "integrity": "sha512-SlT0+bLA0Lg3VthGje+bSZatlGHw/vwgQywx0R/5u9QC59FddTQSPJeWNw29M6f8ScORMeUOOTwihlQAn4GkJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.0.tgz",
+      "integrity": "sha512-HFdvqf2+w8sWOuwtEXayGzdZ2vWpCKEQv5F7+2DSA74Te/Cv4rvb2E5So5/lh+ok4/RAIPuvCbCb/SHQFzMmbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.0.tgz",
+      "integrity": "sha512-Tn7emHAlvYDFik3vGU0mdwvWJDwtITtkJ+5eT2cUquct6nIs+H8M47sqMJkCpyPe5QIBJoTOHxmc6mj9lz6zDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.51.0.tgz",
+      "integrity": "sha512-cMKASxCX4aFxesoj3WK8uoQ0YUrRvnfxaO72QWI2xLu5ZtgX/QvdGBlU3Ehdond5eb74c2s1cqRQUIptBnKz1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.0.tgz",
+      "integrity": "sha512-mtVv6UeaaSaWTeZtLo4cx4P5/ING2obSqfWGItIFSunQBrYROfhuVe7wdIrFUs2RH1tn2YYpAJyMaRe/bnTTIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.0.tgz",
+      "integrity": "sha512-tWWyymgwYcTwZ4t8/rLDfPYbOTF3oYB8SxnYMtIQ1zEf5uDm90Ku3i6U/vhaMyfHNlIHvDhvJh+qx5Nc4Z3Acg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.26"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.0.tgz",
+      "integrity": "sha512-qLslv/EPuLj0IXFvcE3b0EqhWI8LKmrgRPIa4gUd8DllbBpqJAvLNJSv3cC6vWwovpbSI3bagNO/3Q2SuXv2xA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-nestjs-core": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.44.0.tgz",
+      "integrity": "sha512-t16pQ7A4WYu1yyQJZhRKIfUNvl5PAaF2pEteLvgJb/BWdd1oNuU1rOYt4S825kMy+0q4ngiX281Ss9qiwHfxFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.50.0.tgz",
+      "integrity": "sha512-TtLxDdYZmBhFswm8UIsrDjh/HFBeDXd4BLmE8h2MxirNHewLJ0VS9UUddKKEverb5Sm2qFVjqRjcU+8Iw4FJ3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/sql-common": "^0.40.1",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.6"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.0.tgz",
+      "integrity": "sha512-9zhjDpUDOtD+coeADnYEJQ0IeLVCj7w/hqzIutdp5NqS1VqTAanaEfsEcSypyvYv5DX3YOsTUoF+nr2wDXPETA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation-undici": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.0.tgz",
+      "integrity": "sha512-vm+V255NGw9gaSsPD6CP0oGo8L55BffBc8KnxqsMuc6XiAD1L8SFNzsW0RHhxJFqy9CJaJh+YiJ5EHXuZ5rZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.57.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/redis-common": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
+      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
+      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.55.0.tgz",
+      "integrity": "sha512-UvatdmSr3Xf+4PLBzJNLZ2JjG1yAPWGe/VrJlJAqyTJ2gKeTzgXJJw8rp4pbvNZO8NaTGEYhhO+scLUj0UtLAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/context-async-hooks": "^1.30.1",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/instrumentation": "^0.57.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1",
+        "@opentelemetry/semantic-conventions": "^1.28.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@types/connect": {
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@types/mysql": {
+      "version": "2.15.26",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
+      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/import-in-the-middle": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
+      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.5",
@@ -6491,6 +7417,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
     },
     "node_modules/@types/stream-buffers": {
       "version": "3.0.8",
@@ -8945,6 +9877,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9990,6 +10937,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -10353,6 +11306,26 @@
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10504,6 +11477,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -10764,6 +11743,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/tar-fs": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "@sentry/node": "^8",
     "@graphql-hive/gateway": "^2.1.19",
     "@graphql-hive/router-runtime": "^1.0.1",
     "@graphql-mesh/compose-cli": "^1.5.3",

--- a/src/gateway/clients/k8s.ts
+++ b/src/gateway/clients/k8s.ts
@@ -100,12 +100,16 @@ export function createMTLSFetch(mtlsConfig: K8sMTLSConfig): typeof fetch {
   const key = readFileSync(mtlsConfig.keyPath, 'utf8')
   const ca = readFileSync(mtlsConfig.caPath, 'utf8')
 
-  // Create HTTPS agent with mTLS
+  // Create HTTPS agent with mTLS and connection keep-alive to avoid
+  // a full TCP + mTLS handshake on every request.
   const agent = new https.Agent({
     cert,
     key,
     ca,
     rejectUnauthorized: true,
+    keepAlive: true,
+    keepAliveMsecs: 60_000,
+    maxSockets: 50,
   })
 
   log.info('mTLS fetch created successfully')
@@ -115,13 +119,21 @@ export function createMTLSFetch(mtlsConfig: K8sMTLSConfig): typeof fetch {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
     const parsedUrl = new URL(url)
 
+    // Normalise headers to a plain object so https.request can read them
+    // regardless of whether the caller passed a Headers instance or a plain object.
+    const rawHeaders = init?.headers
+    const headers: Record<string, string> =
+      rawHeaders instanceof Headers
+        ? Object.fromEntries(rawHeaders.entries())
+        : (rawHeaders as Record<string, string>) ?? {}
+
     return new Promise((resolve, reject) => {
       const options: https.RequestOptions = {
         hostname: parsedUrl.hostname,
         port: parsedUrl.port || 443,
         path: parsedUrl.pathname + parsedUrl.search,
         method: init?.method || 'GET',
-        headers: init?.headers as Record<string, string>,
+        headers,
         agent,
       }
 
@@ -146,6 +158,13 @@ export function createMTLSFetch(mtlsConfig: K8sMTLSConfig): typeof fetch {
       req.on('error', (error) => {
         log.error('mTLS request failed', { url, error: error.message })
         reject(error)
+      })
+
+      // Propagate abort signal so upstream requests are cancelled when the
+      // client disconnects — frees mTLS agent sockets without waiting for milo.
+      init?.signal?.addEventListener('abort', () => {
+        req.destroy()
+        reject(new DOMException('The operation was aborted.', 'AbortError'))
       })
 
       // Write body if present

--- a/src/gateway/clients/k8s.ts
+++ b/src/gateway/clients/k8s.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import * as https from 'node:https'
 import { KubeConfig } from '@kubernetes/client-node'
+import * as Sentry from '@sentry/node'
 import { log } from '@/shared/utils'
 
 export interface K8sAuthConfig {
@@ -118,6 +119,7 @@ export function createMTLSFetch(mtlsConfig: K8sMTLSConfig): typeof fetch {
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
     const parsedUrl = new URL(url)
+    const method = init?.method || 'GET'
 
     // Normalise headers to a plain object so https.request can read them
     // regardless of whether the caller passed a Headers instance or a plain object.
@@ -127,52 +129,70 @@ export function createMTLSFetch(mtlsConfig: K8sMTLSConfig): typeof fetch {
         ? Object.fromEntries(rawHeaders.entries())
         : (rawHeaders as Record<string, string>) ?? {}
 
-    return new Promise((resolve, reject) => {
-      const options: https.RequestOptions = {
-        hostname: parsedUrl.hostname,
-        port: parsedUrl.port || 443,
-        path: parsedUrl.pathname + parsedUrl.search,
-        method: init?.method || 'GET',
-        headers,
-        agent,
-      }
+    return Sentry.startSpan(
+      {
+        op: 'http.client',
+        name: `${method} ${parsedUrl.pathname}`,
+        attributes: {
+          'http.request.method': method,
+          'url.full': url,
+          'server.address': parsedUrl.hostname,
+          'server.port': Number(parsedUrl.port) || 443,
+        },
+      },
+      (span) =>
+        new Promise<Response>((resolve, reject) => {
+          const options: https.RequestOptions = {
+            hostname: parsedUrl.hostname,
+            port: parsedUrl.port || 443,
+            path: parsedUrl.pathname + parsedUrl.search,
+            method,
+            headers,
+            agent,
+          }
 
-      const req = https.request(options, (res) => {
-        const chunks: Buffer[] = []
+          const req = https.request(options, (res) => {
+            const chunks: Buffer[] = []
 
-        res.on('data', (chunk: Buffer) => chunks.push(chunk))
-        res.on('end', () => {
-          const body = Buffer.concat(chunks).toString('utf8')
+            res.on('data', (chunk: Buffer) => chunks.push(chunk))
+            res.on('end', () => {
+              const statusCode = res.statusCode || 200
+              span.setAttribute('http.response.status_code', statusCode)
+              if (statusCode >= 400) {
+                span.setStatus({ code: 2, message: res.statusMessage || 'Error' })
+              }
 
-          // Create a Response-like object
-          const response = new Response(body, {
-            status: res.statusCode || 200,
-            statusText: res.statusMessage || 'OK',
-            headers: new Headers(res.headers as Record<string, string>),
+              const body = Buffer.concat(chunks).toString('utf8')
+              const response = new Response(body, {
+                status: statusCode,
+                statusText: res.statusMessage || 'OK',
+                headers: new Headers(res.headers as Record<string, string>),
+              })
+
+              resolve(response)
+            })
           })
 
-          resolve(response)
-        })
-      })
+          req.on('error', (error) => {
+            span.setStatus({ code: 2, message: error.message })
+            log.error('mTLS request failed', { url, error: error.message })
+            reject(error)
+          })
 
-      req.on('error', (error) => {
-        log.error('mTLS request failed', { url, error: error.message })
-        reject(error)
-      })
+          // Propagate abort signal so upstream requests are cancelled when the
+          // client disconnects — frees mTLS agent sockets without waiting for milo.
+          init?.signal?.addEventListener('abort', () => {
+            req.destroy()
+            reject(new DOMException('The operation was aborted.', 'AbortError'))
+          })
 
-      // Propagate abort signal so upstream requests are cancelled when the
-      // client disconnects — frees mTLS agent sockets without waiting for milo.
-      init?.signal?.addEventListener('abort', () => {
-        req.destroy()
-        reject(new DOMException('The operation was aborted.', 'AbortError'))
-      })
+          // Write body if present
+          if (init?.body) {
+            req.write(init.body)
+          }
 
-      // Write body if present
-      if (init?.body) {
-        req.write(init.body)
-      }
-
-      req.end()
-    })
+          req.end()
+        }),
+    )
   }
 }

--- a/src/gateway/config/env.ts
+++ b/src/gateway/config/env.ts
@@ -37,4 +37,13 @@ export const env = {
 
   /** Directory containing TLS certificates for HTTPS (tls.crt and tls.key) */
   certDir: process.env.CERT_DIR || '',
+
+  /** Sentry DSN for error and performance monitoring */
+  sentryDsn: process.env.SENTRY_DSN || '',
+
+  /** Sentry environment name */
+  sentryEnv: process.env.SENTRY_ENV || process.env.NODE_ENV || 'development',
+
+  /** Service version for Sentry release tracking */
+  version: process.env.VERSION || '1.0.0',
 }

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -1,6 +1,10 @@
 // Telemetry must be initialized before any other imports
 import './telemetry/telemetry'
 
+// Sentry must be initialized after OTEL (skipOpenTelemetrySetup hooks into it)
+import { initSentry } from './telemetry/sentry'
+initSentry()
+
 import { createGatewayServer } from './server'
 import { env, scopedEndpoints } from './config'
 import { initAuth, getK8sServer } from './auth'

--- a/src/gateway/runtime/index.ts
+++ b/src/gateway/runtime/index.ts
@@ -1,157 +1,158 @@
-import { Worker } from 'node:worker_threads'
 import { createGatewayRuntime } from '@graphql-hive/gateway'
 import { useOpenTelemetry } from '@graphql-hive/plugin-opentelemetry'
 import { unifiedGraphHandler } from '@graphql-hive/router-runtime'
+import { composeSubgraphs } from '@graphql-mesh/compose-cli'
+import { loadOpenAPISubgraph } from '@omnigraph/openapi'
 import { env } from '@/gateway/config'
-import { getMTLSConfig } from '@/gateway/auth'
+import { getK8sServer, getMTLSFetch } from '@/gateway/auth'
 import { log } from '@/shared/utils'
+import type { ApiEntry } from '@/shared/types'
 import { usePrometheusMetrics } from '@/gateway/metrics/metrics'
 
-/** Cached supergraph SDL - updated by the worker after each composition cycle */
+/** Response shape from /openapi/v3 endpoint */
+interface OpenAPIPathsResponse {
+  paths: Record<string, { serverRelativeURL: string }>
+}
+
+/**
+ * Fetch API list dynamically from the K8s OpenAPI endpoint.
+ * Returns paths like "apis/iam.miloapis.com/v1alpha1".
+ * Called on each polling interval to pick up real-time updates.
+ */
+const fetchApisFromOpenAPI = async (): Promise<ApiEntry[]> => {
+  const server = getK8sServer()
+  const fetchFn = getMTLSFetch()
+  const openApiUrl = `${server}/openapi/v3`
+
+  try {
+    log.info(`Fetching API list from ${openApiUrl}`)
+    const response = await fetchFn(openApiUrl)
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch OpenAPI paths: ${response.status} ${response.statusText}`)
+    }
+
+    const data = (await response.json()) as OpenAPIPathsResponse
+    const apis = Object.keys(data.paths).map((path) => ({ path }))
+
+    log.info(`Discovered ${apis.length} APIs from OpenAPI endpoint`, {
+      apis: apis.map((a) => a.path),
+    })
+
+    return apis
+  } catch (error) {
+    log.error(`Failed to fetch APIs from OpenAPI endpoint: ${error}`)
+    throw error
+  }
+}
+
+/** Logger wrapper compatible with GraphQL Mesh Logger interface */
+const noop = () => {}
+const meshLogger = {
+  log: noop,
+  debug: noop,
+  info: noop,
+  warn: console.warn.bind(console),
+  error: console.error.bind(console),
+  child: () => meshLogger,
+}
+
+/**
+ * Derive a unique subgraph name from an API path.
+ * e.g., "apis/iam.miloapis.com/v1alpha1" -> "APIS_IAM_MILOAPIS_COM_V1ALPHA1"
+ * e.g., "api/v1" -> "API_V1"
+ */
+const getSubgraphName = (path: string): string => {
+  return path
+    .replace(/[^a-zA-Z0-9]/g, '_') // Replace non-alphanumeric with underscores
+    .replace(/_+/g, '_') // Collapse multiple underscores
+    .replace(/^_|_$/g, '') // Trim leading/trailing underscores
+    .toUpperCase()
+}
+
+/**
+ * Create subgraph handlers for each API defined in the configuration.
+ * Each subgraph loads its schema from the K8s API server's OpenAPI endpoint.
+ */
+const getSubgraphs = (apis: ApiEntry[]) => {
+  const server = getK8sServer()
+  const fetchFn = getMTLSFetch()
+
+  return apis.map(({ path }) => ({
+    sourceHandler: loadOpenAPISubgraph(getSubgraphName(path), {
+      source: `${server}/openapi/v3/${path}`,
+      endpoint: `${server}{context.headers.x-resource-endpoint-prefix}`,
+      fetch: fetchFn,
+      operationHeaders: {
+        Authorization: '{context.headers.authorization}',
+      },
+    }),
+  }))
+}
+
+/** Cached supergraph SDL - updated by background polling */
 let supergraphSdl: string = ''
 
-/**
- * Guards against overlapping composition cycles.
- * When the polling interval fires while a cycle is already running the new
- * trigger is silently dropped – the in-progress result will be used instead.
- */
-let isComposing = false
-
-/** True once the first composition has succeeded and supergraphSdl is valid */
-let isReady = false
-
-/** Persistent worker thread that owns all composition CPU & I/O work */
-let composeWorker: Worker | null = null
+/** In-flight composition promise - prevents concurrent recompositions */
+let composeInFlight: Promise<string> | null = null
 
 /**
- * Reject function for the currently in-flight composeSupergraph() Promise.
+ * Compose supergraph by fetching OpenAPI specs at runtime.
+ * Called on startup and periodically based on pollingInterval.
+ * Fetches API list from OpenAPI endpoint on each call for real-time discovery.
+ * Updates the cached supergraphSdl variable.
  *
- * The worker's 'error' and 'exit' events fire on the worker object itself, not
- * inside the Promise executor, so they cannot directly reject the Promise.
- * Storing the reject here lets those handlers abort a pending composition
- * instead of leaving the Promise hanging forever (which would stall startup
- * or silently drop polling cycles).
- *
- * Cleared to null whenever the Promise settles (success, worker error, or exit).
- */
-let pendingReject: ((err: Error) => void) | null = null
-
-/**
- * Resolve the worker script path for the current runtime environment.
- */
-const resolveWorkerPath = (): { url: URL; execArgv: string[] } => {
-  const isDev = new URL(import.meta.url).pathname.endsWith('.ts')
-  return isDev
-    ? { url: new URL('./compose-worker.ts', import.meta.url), execArgv: ['--import', 'tsx'] }
-    : { url: new URL('./compose-worker.js', import.meta.url), execArgv: [] }
-}
-
-/**
- * Spawn the persistent composition worker thread.
- *
- * mTLS config is passed via workerData so the worker can authenticate against
- * the k8s API server without importing from our path-aliased source modules
- */
-const startWorker = (): Worker => {
-  const { url, execArgv } = resolveWorkerPath()
-  const { server, certPath, keyPath, caPath } = getMTLSConfig()
-
-  const worker = new Worker(url, {
-    execArgv,
-    workerData: { server, certPath, keyPath, caPath },
-  })
-
-  worker.on('error', (err) => {
-    log.error(`Composition worker error: ${err}`)
-    isComposing = false
-    // Reject any in-flight composeSupergraph() Promise so the caller
-    // (initializeGateway or the polling setInterval) is notified immediately
-    // rather than waiting forever for a message that will never arrive.
-    pendingReject?.(err)
-    pendingReject = null
-  })
-
-  worker.on('exit', (code) => {
-    if (code !== 0) {
-      const err = new Error(`Composition worker exited unexpectedly with code ${code}`)
-      log.error(err.message)
-      isComposing = false
-      pendingReject?.(err)
-      pendingReject = null
-    }
-  })
-
-  return worker
-}
-
-/**
- * Trigger a supergraph composition cycle in the worker thread.
- *
- * Posts a `{ type: 'compose' }` message to the worker and resolves with the
- * new SDL when the worker responds.  All CPU-intensive work (OpenAPI fetching,
- * schema conversion, composeSubgraphs) runs entirely in the worker thread so
- * the main event loop stays free to serve HTTP requests throughout.
- *
- * If a cycle is already running the function returns the current cached SDL
- * immediately – overlapping cycles are dropped, not queued.
+ * Concurrent calls share the same in-flight promise to avoid redundant work.
  */
 const composeSupergraph = (): Promise<string> => {
-  if (isComposing) {
-    log.info('Supergraph composition already in progress, skipping...')
-    return Promise.resolve(supergraphSdl)
+  if (composeInFlight) {
+    return composeInFlight
   }
+  composeInFlight = _composeSupergraph().finally(() => {
+    composeInFlight = null
+  })
+  return composeInFlight
+}
 
-  isComposing = true
+const _composeSupergraph = async (): Promise<string> => {
   log.info('Composing supergraph from OpenAPI specs...')
 
-  return new Promise((resolve, reject) => {
-    pendingReject = reject
+  // Fetch APIs dynamically from OpenAPI endpoint on each poll
+  const apis = await fetchApisFromOpenAPI()
+  const handlers = getSubgraphs(apis)
+  const subgraphs = await Promise.all(
+    handlers.map(async ({ sourceHandler }) => {
+      const result = sourceHandler({
+        fetch: globalThis.fetch,
+        cwd: process.cwd(),
+        logger: meshLogger,
+      })
+      const schema = await result.schema$
+      return { name: result.name, schema }
+    })
+  )
 
-    const handler = (result: { sdl?: string; error?: string }) => {
-      pendingReject = null
-      isComposing = false
+  const result = composeSubgraphs(subgraphs)
+  supergraphSdl = result.supergraphSdl
+  log.info('Supergraph composed successfully')
 
-      if (result.error) {
-        log.error(`Supergraph composition failed: ${result.error}`)
-        reject(new Error(result.error))
-      } else {
-        supergraphSdl = result.sdl!
-        isReady = true
-        log.info('Supergraph composed successfully')
-        resolve(result.sdl!)
-      }
-    }
-
-    composeWorker!.once('message', handler)
-    composeWorker!.postMessage({ type: 'compose' })
-  })
+  return result.supergraphSdl
 }
 
 /**
- * Returns the cached supergraph SDL synchronously.
- *
- * This is passed directly to `createGatewayRuntime` as the `supergraph`
- * option.  Because it returns a plain string (not a Promise), Hive Gateway
- * treats the schema as already resolved and never awaits anything on the
- * request path.  The cache is updated in the background by the worker thread
- * without ever touching request handling.
+ * Returns the cached supergraph SDL.
+ * Falls back to composing if not ready (safety mechanism).
  */
-const getSupergraph = (): string => {
+const getSupergraph = async (): Promise<string> => {
   if (!supergraphSdl) {
-    log.warn('Supergraph not ready yet – returning empty SDL')
+    log.warn('Supergraph not ready, composing on demand...')
+    return composeSupergraph()
   }
   return supergraphSdl
 }
 
-/** True once the supergraph has been composed at least once successfully */
-export const isSupergraphReady = (): boolean => isReady
-
 /**
- * Start background polling to keep the supergraph SDL fresh.
- *
- * Each tick sends a compose request to the worker thread.  The main event
- * loop is never blocked – the worker does all the heavy lifting and posts
- * the result back asynchronously.
+ * Start background polling to refresh the supergraph SDL.
  */
 const startPolling = (): void => {
   setInterval(async () => {
@@ -164,15 +165,10 @@ const startPolling = (): void => {
 }
 
 /**
- * Bootstrap the gateway: spawn the composition worker, run the first
- * composition eagerly (blocking startup until the SDL is ready), then kick
- * off background polling.
- *
- * Must complete before the HTTP server begins accepting connections so that
- * `getSupergraph()` always returns a valid SDL on the very first request.
+ * Initialize the gateway: compose supergraph eagerly, then start background polling.
+ * Must be called before handling requests.
  */
 export const initializeGateway = async (): Promise<void> => {
-  composeWorker = startWorker()
   await composeSupergraph()
   startPolling()
   log.info(`Background polling started (interval: ${env.pollingInterval}ms)`)

--- a/src/gateway/runtime/index.ts
+++ b/src/gateway/runtime/index.ts
@@ -1,158 +1,157 @@
+import { Worker } from 'node:worker_threads'
 import { createGatewayRuntime } from '@graphql-hive/gateway'
 import { useOpenTelemetry } from '@graphql-hive/plugin-opentelemetry'
 import { unifiedGraphHandler } from '@graphql-hive/router-runtime'
-import { composeSubgraphs } from '@graphql-mesh/compose-cli'
-import { loadOpenAPISubgraph } from '@omnigraph/openapi'
 import { env } from '@/gateway/config'
-import { getK8sServer, getMTLSFetch } from '@/gateway/auth'
+import { getMTLSConfig } from '@/gateway/auth'
 import { log } from '@/shared/utils'
-import type { ApiEntry } from '@/shared/types'
 import { usePrometheusMetrics } from '@/gateway/metrics/metrics'
 
-/** Response shape from /openapi/v3 endpoint */
-interface OpenAPIPathsResponse {
-  paths: Record<string, { serverRelativeURL: string }>
-}
-
-/**
- * Fetch API list dynamically from the K8s OpenAPI endpoint.
- * Returns paths like "apis/iam.miloapis.com/v1alpha1".
- * Called on each polling interval to pick up real-time updates.
- */
-const fetchApisFromOpenAPI = async (): Promise<ApiEntry[]> => {
-  const server = getK8sServer()
-  const fetchFn = getMTLSFetch()
-  const openApiUrl = `${server}/openapi/v3`
-
-  try {
-    log.info(`Fetching API list from ${openApiUrl}`)
-    const response = await fetchFn(openApiUrl)
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch OpenAPI paths: ${response.status} ${response.statusText}`)
-    }
-
-    const data = (await response.json()) as OpenAPIPathsResponse
-    const apis = Object.keys(data.paths).map((path) => ({ path }))
-
-    log.info(`Discovered ${apis.length} APIs from OpenAPI endpoint`, {
-      apis: apis.map((a) => a.path),
-    })
-
-    return apis
-  } catch (error) {
-    log.error(`Failed to fetch APIs from OpenAPI endpoint: ${error}`)
-    throw error
-  }
-}
-
-/** Logger wrapper compatible with GraphQL Mesh Logger interface */
-const noop = () => {}
-const meshLogger = {
-  log: noop,
-  debug: noop,
-  info: noop,
-  warn: console.warn.bind(console),
-  error: console.error.bind(console),
-  child: () => meshLogger,
-}
-
-/**
- * Derive a unique subgraph name from an API path.
- * e.g., "apis/iam.miloapis.com/v1alpha1" -> "APIS_IAM_MILOAPIS_COM_V1ALPHA1"
- * e.g., "api/v1" -> "API_V1"
- */
-const getSubgraphName = (path: string): string => {
-  return path
-    .replace(/[^a-zA-Z0-9]/g, '_') // Replace non-alphanumeric with underscores
-    .replace(/_+/g, '_') // Collapse multiple underscores
-    .replace(/^_|_$/g, '') // Trim leading/trailing underscores
-    .toUpperCase()
-}
-
-/**
- * Create subgraph handlers for each API defined in the configuration.
- * Each subgraph loads its schema from the K8s API server's OpenAPI endpoint.
- */
-const getSubgraphs = (apis: ApiEntry[]) => {
-  const server = getK8sServer()
-  const fetchFn = getMTLSFetch()
-
-  return apis.map(({ path }) => ({
-    sourceHandler: loadOpenAPISubgraph(getSubgraphName(path), {
-      source: `${server}/openapi/v3/${path}`,
-      endpoint: `${server}{context.headers.x-resource-endpoint-prefix}`,
-      fetch: fetchFn,
-      operationHeaders: {
-        Authorization: '{context.headers.authorization}',
-      },
-    }),
-  }))
-}
-
-/** Cached supergraph SDL - updated by background polling */
+/** Cached supergraph SDL - updated by the worker after each composition cycle */
 let supergraphSdl: string = ''
 
-/** In-flight composition promise - prevents concurrent recompositions */
-let composeInFlight: Promise<string> | null = null
+/**
+ * Guards against overlapping composition cycles.
+ * When the polling interval fires while a cycle is already running the new
+ * trigger is silently dropped – the in-progress result will be used instead.
+ */
+let isComposing = false
+
+/** True once the first composition has succeeded and supergraphSdl is valid */
+let isReady = false
+
+/** Persistent worker thread that owns all composition CPU & I/O work */
+let composeWorker: Worker | null = null
 
 /**
- * Compose supergraph by fetching OpenAPI specs at runtime.
- * Called on startup and periodically based on pollingInterval.
- * Fetches API list from OpenAPI endpoint on each call for real-time discovery.
- * Updates the cached supergraphSdl variable.
+ * Reject function for the currently in-flight composeSupergraph() Promise.
  *
- * Concurrent calls share the same in-flight promise to avoid redundant work.
+ * The worker's 'error' and 'exit' events fire on the worker object itself, not
+ * inside the Promise executor, so they cannot directly reject the Promise.
+ * Storing the reject here lets those handlers abort a pending composition
+ * instead of leaving the Promise hanging forever (which would stall startup
+ * or silently drop polling cycles).
+ *
+ * Cleared to null whenever the Promise settles (success, worker error, or exit).
+ */
+let pendingReject: ((err: Error) => void) | null = null
+
+/**
+ * Resolve the worker script path for the current runtime environment.
+ */
+const resolveWorkerPath = (): { url: URL; execArgv: string[] } => {
+  const isDev = new URL(import.meta.url).pathname.endsWith('.ts')
+  return isDev
+    ? { url: new URL('./compose-worker.ts', import.meta.url), execArgv: ['--import', 'tsx'] }
+    : { url: new URL('./compose-worker.js', import.meta.url), execArgv: [] }
+}
+
+/**
+ * Spawn the persistent composition worker thread.
+ *
+ * mTLS config is passed via workerData so the worker can authenticate against
+ * the k8s API server without importing from our path-aliased source modules
+ */
+const startWorker = (): Worker => {
+  const { url, execArgv } = resolveWorkerPath()
+  const { server, certPath, keyPath, caPath } = getMTLSConfig()
+
+  const worker = new Worker(url, {
+    execArgv,
+    workerData: { server, certPath, keyPath, caPath },
+  })
+
+  worker.on('error', (err) => {
+    log.error(`Composition worker error: ${err}`)
+    isComposing = false
+    // Reject any in-flight composeSupergraph() Promise so the caller
+    // (initializeGateway or the polling setInterval) is notified immediately
+    // rather than waiting forever for a message that will never arrive.
+    pendingReject?.(err)
+    pendingReject = null
+  })
+
+  worker.on('exit', (code) => {
+    if (code !== 0) {
+      const err = new Error(`Composition worker exited unexpectedly with code ${code}`)
+      log.error(err.message)
+      isComposing = false
+      pendingReject?.(err)
+      pendingReject = null
+    }
+  })
+
+  return worker
+}
+
+/**
+ * Trigger a supergraph composition cycle in the worker thread.
+ *
+ * Posts a `{ type: 'compose' }` message to the worker and resolves with the
+ * new SDL when the worker responds.  All CPU-intensive work (OpenAPI fetching,
+ * schema conversion, composeSubgraphs) runs entirely in the worker thread so
+ * the main event loop stays free to serve HTTP requests throughout.
+ *
+ * If a cycle is already running the function returns the current cached SDL
+ * immediately – overlapping cycles are dropped, not queued.
  */
 const composeSupergraph = (): Promise<string> => {
-  if (composeInFlight) {
-    return composeInFlight
+  if (isComposing) {
+    log.info('Supergraph composition already in progress, skipping...')
+    return Promise.resolve(supergraphSdl)
   }
-  composeInFlight = _composeSupergraph().finally(() => {
-    composeInFlight = null
-  })
-  return composeInFlight
-}
 
-const _composeSupergraph = async (): Promise<string> => {
+  isComposing = true
   log.info('Composing supergraph from OpenAPI specs...')
 
-  // Fetch APIs dynamically from OpenAPI endpoint on each poll
-  const apis = await fetchApisFromOpenAPI()
-  const handlers = getSubgraphs(apis)
-  const subgraphs = await Promise.all(
-    handlers.map(async ({ sourceHandler }) => {
-      const result = sourceHandler({
-        fetch: globalThis.fetch,
-        cwd: process.cwd(),
-        logger: meshLogger,
-      })
-      const schema = await result.schema$
-      return { name: result.name, schema }
-    })
-  )
+  return new Promise((resolve, reject) => {
+    pendingReject = reject
 
-  const result = composeSubgraphs(subgraphs)
-  supergraphSdl = result.supergraphSdl
-  log.info('Supergraph composed successfully')
+    const handler = (result: { sdl?: string; error?: string }) => {
+      pendingReject = null
+      isComposing = false
 
-  return result.supergraphSdl
+      if (result.error) {
+        log.error(`Supergraph composition failed: ${result.error}`)
+        reject(new Error(result.error))
+      } else {
+        supergraphSdl = result.sdl!
+        isReady = true
+        log.info('Supergraph composed successfully')
+        resolve(result.sdl!)
+      }
+    }
+
+    composeWorker!.once('message', handler)
+    composeWorker!.postMessage({ type: 'compose' })
+  })
 }
 
 /**
- * Returns the cached supergraph SDL.
- * Falls back to composing if not ready (safety mechanism).
+ * Returns the cached supergraph SDL synchronously.
+ *
+ * This is passed directly to `createGatewayRuntime` as the `supergraph`
+ * option.  Because it returns a plain string (not a Promise), Hive Gateway
+ * treats the schema as already resolved and never awaits anything on the
+ * request path.  The cache is updated in the background by the worker thread
+ * without ever touching request handling.
  */
-const getSupergraph = async (): Promise<string> => {
+const getSupergraph = (): string => {
   if (!supergraphSdl) {
-    log.warn('Supergraph not ready, composing on demand...')
-    return composeSupergraph()
+    log.warn('Supergraph not ready yet – returning empty SDL')
   }
   return supergraphSdl
 }
 
+/** True once the supergraph has been composed at least once successfully */
+export const isSupergraphReady = (): boolean => isReady
+
 /**
- * Start background polling to refresh the supergraph SDL.
+ * Start background polling to keep the supergraph SDL fresh.
+ *
+ * Each tick sends a compose request to the worker thread.  The main event
+ * loop is never blocked – the worker does all the heavy lifting and posts
+ * the result back asynchronously.
  */
 const startPolling = (): void => {
   setInterval(async () => {
@@ -165,10 +164,15 @@ const startPolling = (): void => {
 }
 
 /**
- * Initialize the gateway: compose supergraph eagerly, then start background polling.
- * Must be called before handling requests.
+ * Bootstrap the gateway: spawn the composition worker, run the first
+ * composition eagerly (blocking startup until the SDL is ready), then kick
+ * off background polling.
+ *
+ * Must complete before the HTTP server begins accepting connections so that
+ * `getSupergraph()` always returns a valid SDL on the very first request.
  */
 export const initializeGateway = async (): Promise<void> => {
+  composeWorker = startWorker()
   await composeSupergraph()
   startPolling()
   log.info(`Background polling started (interval: ${env.pollingInterval}ms)`)

--- a/src/gateway/telemetry/sentry.ts
+++ b/src/gateway/telemetry/sentry.ts
@@ -1,0 +1,29 @@
+import * as Sentry from '@sentry/node'
+import { env } from '@/gateway/config'
+import { log } from '@/shared/utils'
+
+/**
+ * Initialize Sentry for error reporting and performance monitoring.
+ *
+ * Must be called after OpenTelemetry is set up (telemetry.ts) so that
+ * skipOpenTelemetrySetup can hook into the already-registered providers
+ * rather than creating a duplicate TracerProvider.
+ */
+export function initSentry(): void {
+  if (!env.sentryDsn) {
+    log.info('[sentry] SENTRY_DSN not set, Sentry disabled')
+    return
+  }
+
+  Sentry.init({
+    dsn: env.sentryDsn,
+    environment: env.sentryEnv,
+    release: env.version,
+    tracesSampleRate: 1.0,
+    // OTEL is already configured via telemetry.ts — tell Sentry to hook into
+    // the existing providers instead of registering its own.
+    skipOpenTelemetrySetup: true,
+  })
+
+  log.info('[sentry] Initialized', { environment: env.sentryEnv, release: env.version })
+}


### PR DESCRIPTION
## Summary

- **Add Sentry observability**: initialise `@sentry/node` with `skipOpenTelemetrySetup: true` so it hooks into the existing OTEL providers. Wrap every mTLS fetch to milo in a `http.client` span with method, URL, and response status attributes — 4xx/5xx responses are marked as errored. This gives end-to-end trace visibility from portal through gateway into milo when paired with https://github.com/datum-cloud/cloud-portal/pull/1095. Requires `SENTRY_DSN`, `SENTRY_ENV`, and `VERSION` env vars.
- **Fix mTLS headers forwarding**: `init.headers` was cast directly as `Record<string, string>` — if the caller passes a `Headers` instance (as `@omnigraph/openapi` and `@graphql-hive/gateway` commonly do), `https.request` receives an object with no own enumerable properties and sends no headers. Without `Authorization`, milo authenticates the request as anonymous, hits both auth and authz webhooks before rejecting, adding several seconds of latency per request.
- **Add `AbortSignal` propagation to mTLS fetch**: client disconnects now destroy the underlying `https.request` immediately rather than holding a connection slot in the mTLS agent pool until milo responds.
- **Add `keepAlive` / `maxSockets` to HTTPS agent**: reuses TLS connections across requests instead of performing a full handshake each time.

## Test plan

- [ ] Set `SENTRY_DSN` and load `/account/organizations` — confirm a `http.client` span appears in Sentry with the milo request URL and status code
- [ ] Trigger a 4xx from milo (e.g. invalid auth) and confirm the span is marked as errored in Sentry
- [ ] Verify GraphQL requests to the user-scoped endpoint return data (not auth errors) — confirms `Authorization` header is now forwarded correctly
- [ ] Simulate a client disconnect mid-request and confirm the mTLS connection is released promptly (check mTLS agent socket count)