### PR TITLE
fix: bake VERSION into Docker image from CI build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,13 @@ RUN npm run build
 # --- Stage 2: Runtime ---
 FROM node:22-slim
 
+ARG VERSION=dev
+
 WORKDIR /app
 
 # Set the environment to production
 ENV NODE_ENV=production
+ENV VERSION=${VERSION}
 
 # Copy package files
 COPY package.json package-lock.json ./

--- a/src/gateway/config/env.ts
+++ b/src/gateway/config/env.ts
@@ -45,5 +45,5 @@ export const env = {
   sentryEnv: process.env.SENTRY_ENV || process.env.NODE_ENV || 'development',
 
   /** Service version for Sentry release tracking */
-  version: process.env.VERSION || '1.0.0',
+  version: process.env.VERSION || 'dev',
 }


### PR DESCRIPTION
## Summary

- Adds `ARG VERSION=dev` and `ENV VERSION=${VERSION}` to the Dockerfile so the CI pipeline can inject the real version at build time
- Changes the `env.ts` fallback from `'1.0.0'` to `'dev'` for local development
- The infra patch previously hardcoded `VERSION=1.0.0` at runtime, overriding the correct value — that hardcoding is removed in the companion infra PR

The shared CI action (`publish-docker.yaml`) already passes a semver-compatible `VERSION` build arg. Sentry will now correctly identify each deployment by its actual released version, enabling accurate release health tracking and regression detection.

## Test plan

- [ ] Confirm built image has correct `VERSION` env var matching the git tag/SHA
- [ ] Verify Sentry `release` field reflects the deployed version (not `1.0.0`)