### PR TITLE
feat: add subgraph error alerts and runbook

### DIFF
--- a/config/components/observability/alerts/subgraph-errors.yaml
+++ b/config/components/observability/alerts/subgraph-errors.yaml
@@ -1,0 +1,41 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: graphql-gateway-alerts
+spec:
+  groups:
+    - name: graphql-gateway
+      rules:
+        - alert: GraphQLGatewaySubgraphErrors
+          expr: |
+            increase(graphql_gateway_subgraph_execute_errors[5m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              GraphQL gateway subgraph {{ $labels.subgraphName }} has
+              errors ({{ $value | humanize }} in 5m)
+            description: >-
+              The graphql-gateway pod {{ $labels.pod }} is failing to
+              execute requests against subgraph {{ $labels.subgraphName }}.
+              This typically indicates a TLS certificate issue or the
+              downstream API server being unreachable.
+            runbook_url: "https://github.com/datum-cloud/graphql-gateway/blob/main/docs/runbooks/subgraph-errors.md"
+        - alert: GraphQLGatewaySubgraphErrorsSustained
+          expr: |
+            increase(graphql_gateway_subgraph_execute_errors[15m]) > 5
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              GraphQL gateway subgraph {{ $labels.subgraphName }} has
+              sustained errors ({{ $value | humanize }} in 15m)
+            description: >-
+              The graphql-gateway pod {{ $labels.pod }} has been failing
+              requests against subgraph {{ $labels.subgraphName }} for
+              over 10 minutes. Users are likely unable to load
+              organization memberships or other data served by this
+              subgraph.
+            runbook_url: "https://github.com/datum-cloud/graphql-gateway/blob/main/docs/runbooks/subgraph-errors.md"

--- a/config/components/observability/kustomization.yaml
+++ b/config/components/observability/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
 
   # Grafana dashboards
   - dashboards/
+
+  # Alerting rules
+  - alerts/subgraph-errors.yaml

--- a/docs/runbooks/subgraph-errors.md
+++ b/docs/runbooks/subgraph-errors.md
@@ -1,0 +1,109 @@
+# GraphQLGatewaySubgraphErrors / GraphQLGatewaySubgraphErrorsSustained
+
+## Alert description
+
+The graphql-gateway is failing to execute requests against one or more
+downstream subgraph APIs. The `subgraphName` label identifies which API
+is affected (e.g., `APIS_RESOURCEMANAGER_MILOAPIS_COM_V1ALPHA1`).
+
+**Warning** fires after any errors sustained for 5 minutes.
+**Critical** fires after >5 errors in 15 minutes, sustained for 10 minutes.
+
+## Impact
+
+Users will see errors or missing data for the affected subgraph. For
+example, if `APIS_RESOURCEMANAGER_MILOAPIS_COM_V1ALPHA1` is failing,
+organization membership queries will return errors.
+
+## Investigation
+
+### 1. Check the graphql-gateway logs
+
+```sh
+kubectl logs -n graphql-gateway -l app.kubernetes.io/name=graphql-gateway --tail=50 | grep ERR
+```
+
+Look for the error message. Common errors:
+
+| Error | Cause |
+|---|---|
+| `unable to verify the first certificate` | TLS CA trust issue |
+| `ECONNREFUSED` | Downstream API server is down |
+| `ETIMEDOUT` | Network connectivity or DNS issue |
+| `certificate has expired` | Expired serving cert |
+
+### 2. TLS verification failure (`unable to verify the first certificate`)
+
+This means Node.js cannot verify the downstream API server's TLS
+certificate against its trusted CA bundle.
+
+**Check `NODE_EXTRA_CA_CERTS` is set:**
+```sh
+kubectl exec -n graphql-gateway deploy/graphql-gateway -- env | grep NODE_EXTRA_CA_CERTS
+```
+
+Expected: `NODE_EXTRA_CA_CERTS=/etc/ssl/certs/datum-ca.crt`
+
+If missing, the Flux Kustomization patches may have been overwritten by
+an environment overlay. See [infra#2188](https://github.com/datum-cloud/infra/pull/2188)
+for the root cause pattern.
+
+**Verify the CA file exists in the pod:**
+```sh
+kubectl exec -n graphql-gateway deploy/graphql-gateway -- cat /etc/ssl/certs/datum-ca.crt | openssl x509 -noout -subject -dates
+```
+
+**Test TLS from the pod:**
+```sh
+kubectl exec -n graphql-gateway deploy/graphql-gateway -- node -e "
+const https = require('https');
+const fs = require('fs');
+const ca = fs.readFileSync('/etc/ssl/certs/datum-ca.crt');
+https.get({
+  hostname: 'milo-apiserver.datum-system.svc.cluster.local',
+  port: 6443, path: '/healthz', ca,
+  cert: fs.readFileSync('/etc/kubernetes/pki/client/tls.crt'),
+  key: fs.readFileSync('/etc/kubernetes/pki/client/tls.key'),
+}, (res) => console.log('Status:', res.statusCode))
+.on('error', (e) => console.log('Error:', e.message));
+"
+```
+
+### 3. Downstream API server unavailable
+
+Check if the milo-apiserver is running:
+```sh
+kubectl get pods -n datum-system -l app=milo-apiserver
+```
+
+Check the aggregated API service health:
+```sh
+kubectl get apiservice | grep resourcemanager
+```
+
+### 4. Certificate rotation
+
+If certs were recently rotated (e.g., after a milo-apiserver restart),
+the graphql-gateway may need a restart to pick up the new trust bundle:
+
+```sh
+kubectl rollout restart deployment/graphql-gateway -n graphql-gateway
+```
+
+## Resolution
+
+- **Missing `NODE_EXTRA_CA_CERTS`**: Fix the Flux Kustomization patches
+  in the infra repo. Use JSON patch (`op: add`, `path: /spec/patches/-`)
+  to append environment-specific patches instead of replacing base patches.
+- **Downstream API down**: Check milo-apiserver and the aggregated API
+  service. Restart if needed.
+- **Expired cert**: cert-manager CSI should auto-renew. If not, check
+  the ClusterIssuer and CertificateRequest status.
+
+## Metric
+
+```promql
+increase(graphql_gateway_subgraph_execute_errors[5m])
+```
+
+Labels: `subgraphName`, `pod`, `operationName`, `operationType`


### PR DESCRIPTION
## Summary

Add alerting and runbook for graphql-gateway subgraph execution errors.

## Motivation

[infra#2188](https://github.com/datum-cloud/infra/pull/2188) — a TLS cert trust issue (`unable to verify the first certificate`) caused all requests to the resourcemanager subgraph to fail in production. It went undetected until users reported it because there was no alerting on `graphql_gateway_subgraph_execute_errors`.

## Changes

### Alerts (`config/components/observability/alerts/subgraph-errors.yaml`)

| Alert | Threshold | For | Severity |
|---|---|---|---|
| `GraphQLGatewaySubgraphErrors` | any errors in 5m | 5m | warning |
| `GraphQLGatewaySubgraphErrorsSustained` | >5 errors in 15m | 10m | critical |

Verified the expression catches the current production errors:
```promql
increase(graphql_gateway_subgraph_execute_errors[5m]) > 0
→ subgraphName="APIS_RESOURCEMANAGER_MILOAPIS_COM_V1ALPHA1", value=3
```

### Runbook (`docs/runbooks/subgraph-errors.md`)

Covers:
- TLS verification failures (missing `NODE_EXTRA_CA_CERTS`, CA trust issues)
- Downstream API unavailability
- Certificate rotation scenarios
- Step-by-step investigation commands

## Test plan

- [ ] `kustomize build` renders VMRule correctly
- [ ] Alert expression evaluated against prod VictoriaMetrics — confirmed it fires
- [ ] Runbook steps tested against the current production incident