### PR TITLE
feat: add parseUserAgent and geolocateIP resolvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 dist/
+tmp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "@graphql-mesh/compose-cli": "^1.5.3",
         "@graphql-mesh/plugin-prometheus": "^2.1.13",
         "@kubernetes/client-node": "^1.4.0",
+        "@maxmind/geoip2-node": "^6.3.4",
         "@omnigraph/openapi": "^0.109.23",
         "@opentelemetry/context-async-hooks": "^2.4.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",
         "@sentry/node": "^8",
+        "ua-parser-js": "^2.0.9",
         "yaml": "^2.3.2"
       },
       "devDependencies": {
@@ -4087,6 +4089,14 @@
         "stream-buffers": "^3.0.2",
         "tar-fs": "^3.0.9",
         "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@maxmind/geoip2-node": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/@maxmind/geoip2-node/-/geoip2-node-6.3.4.tgz",
+      "integrity": "sha512-BTRFHCX7Uie4wVSPXsWQfg0EVl4eGZgLCts0BTKAP+Eiyt1zmF2UPyuUZkaj0R59XSDYO+84o1THAtaenUoQYg==",
+      "dependencies": {
+        "maxmind": "^5.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8603,6 +8613,25 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -9937,6 +9966,25 @@
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -10533,6 +10581,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/maxmind": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-5.0.6.tgz",
+      "integrity": "sha512-5bvd/u+kIaTqaGM+xkXjatzQw1dQfSmlLggr2W1EKMyMxSgx2woZyusLpNpZ4DdPmL+1bbJWeo4LXsi6bC0Iew==",
+      "dependencies": {
+        "mmdb-lib": "3.0.2",
+        "tiny-lru": "13.0.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/maxmind/node_modules/tiny-lru": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-13.0.0.tgz",
+      "integrity": "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -10627,6 +10696,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mmdb-lib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-3.0.2.tgz",
+      "integrity": "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==",
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
       }
     },
     "node_modules/module-details-from-path": {
@@ -12041,6 +12119,55 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ]
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
+      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/uncrypto": {

--- a/package.json
+++ b/package.json
@@ -24,15 +24,17 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@sentry/node": "^8",
     "@graphql-hive/gateway": "^2.1.19",
     "@graphql-hive/router-runtime": "^1.0.1",
     "@graphql-mesh/compose-cli": "^1.5.3",
     "@graphql-mesh/plugin-prometheus": "^2.1.13",
     "@kubernetes/client-node": "^1.4.0",
+    "@maxmind/geoip2-node": "^6.3.4",
     "@omnigraph/openapi": "^0.109.23",
     "@opentelemetry/context-async-hooks": "^2.4.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",
+    "@sentry/node": "^8",
+    "ua-parser-js": "^2.0.9",
     "yaml": "^2.3.2"
   },
   "devDependencies": {

--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -53,6 +53,7 @@ fi
 
 LOCAL_DIR="/tmp/graphql-gateway-test"
 NAMESPACE="${NAMESPACE:-datum-system}"
+TRUST_BUNDLE_NAMESPACE="${TRUST_BUNDLE_NAMESPACE:-graphql-gateway}"
 CERT_NAMESPACE="${CERT_NAMESPACE:-default}"
 CERT_NAME="graphql-gateway-local-test"
 APISERVER_HOST="milo-apiserver"
@@ -150,18 +151,18 @@ setup_directories() {
 }
 
 extract_ca_cert() {
-  log_info "Extracting CA certificate from cluster..."
-  
+  log_info "Extracting CA certificate from cluster (namespace: $TRUST_BUNDLE_NAMESPACE)..."
+
   # Try different ConfigMap names
   for cm_name in "datum-control-plane-trust-bundle" "trust-bundle" "datum-control-plane-system-bundle"; do
-    if kubectl get configmap "$cm_name" -n "$NAMESPACE" &>/dev/null; then
-      kubectl get configmap "$cm_name" -n "$NAMESPACE" -o jsonpath='{.data.ca\.crt}' > "$LOCAL_DIR/pki/trust/ca.crt"
+    if kubectl get configmap "$cm_name" -n "$TRUST_BUNDLE_NAMESPACE" &>/dev/null; then
+      kubectl get configmap "$cm_name" -n "$TRUST_BUNDLE_NAMESPACE" -o jsonpath='{.data.ca\.crt}' > "$LOCAL_DIR/pki/trust/ca.crt"
       log_info "CA certificate extracted from ConfigMap: $cm_name"
       return 0
     fi
   done
-  
-  log_error "Could not find CA certificate ConfigMap. Please manually copy CA to: $LOCAL_DIR/pki/trust/ca.crt"
+
+  log_error "Could not find CA certificate ConfigMap in $TRUST_BUNDLE_NAMESPACE. Please manually copy CA to: $LOCAL_DIR/pki/trust/ca.crt"
   return 1
 }
 

--- a/src/gateway/config/env.ts
+++ b/src/gateway/config/env.ts
@@ -46,4 +46,7 @@ export const env = {
 
   /** Service version for Sentry release tracking */
   version: process.env.VERSION || 'dev',
+
+  /** Path to the MaxMind GeoLite2-City.mmdb database file */
+  maxmindDbPath: process.env.MAXMIND_DB_PATH || '',
 }

--- a/src/gateway/graphql/index.ts
+++ b/src/gateway/graphql/index.ts
@@ -1,0 +1,2 @@
+export { additionalTypeDefs } from './typeDefs'
+export { additionalResolvers } from './resolvers'

--- a/src/gateway/graphql/index.ts
+++ b/src/gateway/graphql/index.ts
@@ -1,2 +1,3 @@
 export { additionalTypeDefs } from './typeDefs'
 export { additionalResolvers } from './resolvers'
+export { useGatewayLocalSchema } from './plugin'

--- a/src/gateway/graphql/plugin.ts
+++ b/src/gateway/graphql/plugin.ts
@@ -1,0 +1,93 @@
+import {
+  parse,
+  extendSchema,
+  execute as defaultExecute,
+  Kind,
+  type GraphQLSchema,
+  type DocumentNode,
+  type OperationDefinitionNode,
+  type FieldNode,
+} from 'graphql'
+import { addResolversToSchema } from '@graphql-tools/schema'
+import type { Plugin } from 'graphql-yoga'
+import type { IResolvers } from '@graphql-tools/utils'
+import { additionalTypeDefs } from './typeDefs'
+import { additionalResolvers } from './resolvers'
+
+/**
+ * Top-level Query field names that are resolved locally by the gateway and
+ * should NOT be planned by the Hive Router.  Derived from the resolver map so
+ * the two stay in sync.
+ */
+const LOCAL_QUERY_FIELDS: ReadonlySet<string> = new Set(
+  Object.keys((additionalResolvers as { Query?: Record<string, unknown> }).Query ?? {})
+)
+
+/**
+ * Returns true when every top-level selection on the operation is a local
+ * gateway field.  Queries that mix local + federated fields fall back to the
+ * router (which will fail – we don't currently support mixed operations).
+ */
+const isPurelyLocalOperation = (doc: DocumentNode, opName?: string | null): boolean => {
+  const op = doc.definitions.find(
+    (d): d is OperationDefinitionNode =>
+      d.kind === Kind.OPERATION_DEFINITION &&
+      d.operation === 'query' &&
+      (!opName || d.name?.value === opName)
+  )
+  if (!op) return false
+
+  const topLevelFields = op.selectionSet.selections.filter(
+    (s): s is FieldNode => s.kind === Kind.FIELD
+  )
+  if (topLevelFields.length === 0) return false
+
+  return topLevelFields.every((f) => LOCAL_QUERY_FIELDS.has(f.name.value))
+}
+
+/**
+ * Adds gateway-local fields (e.g. parseUserAgent, geolocateIP) to the unified
+ * graph schema produced by the Hive Router and routes their execution to the
+ * default GraphQL executor.
+ *
+ * Two phases:
+ *
+ * 1. `onSchemaChange` – extends the router's schema with our type defs +
+ *    resolvers so that validation succeeds for local fields.  The Hive Router
+ *    (`@graphql-hive/router-runtime`'s `unifiedGraphHandler`) ignores
+ *    `additionalTypeDefs` / `additionalResolvers` on `createGatewayRuntime`
+ *    config, so we have to do it ourselves here.
+ *
+ * 2. `onExecute` – for operations that only select local fields, swap the
+ *    executor for the default `graphql.execute`.  Otherwise the router would
+ *    try to plan the operation against the supergraph SDL (which knows nothing
+ *    about local fields) and fail with "Field 'X' not found in type 'Query'".
+ */
+export const useGatewayLocalSchema = (): Plugin => {
+  const ast = parse(additionalTypeDefs)
+  const extended = new WeakSet<GraphQLSchema>()
+
+  return {
+    onSchemaChange({ schema, replaceSchema }) {
+      if (!schema || extended.has(schema)) return
+
+      const withTypes = extendSchema(schema, ast, {
+        assumeValid: true,
+        assumeValidSDL: true,
+      })
+      const withResolvers = addResolversToSchema({
+        schema: withTypes,
+        resolvers: additionalResolvers as IResolvers,
+      })
+
+      extended.add(withResolvers)
+      replaceSchema(withResolvers)
+    },
+
+    onExecute({ args, setExecuteFn }) {
+      if (isPurelyLocalOperation(args.document, args.operationName)) {
+        setExecuteFn(defaultExecute)
+      }
+    },
+  }
+}

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -1,0 +1,14 @@
+import { parseUserAgent } from '@/gateway/services/user-agent'
+import { lookupIp } from '@/gateway/services/geolocation'
+
+export const additionalResolvers = {
+  Query: {
+    parseUserAgent: (_root: unknown, args: { userAgent: string }) => {
+      return parseUserAgent(args.userAgent)
+    },
+
+    geolocateIP: (_root: unknown, args: { ip: string }) => {
+      return lookupIp(args.ip)
+    },
+  },
+}

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -1,0 +1,19 @@
+export const additionalTypeDefs = /* GraphQL */ `
+  type ParsedUserAgent {
+    browser: String
+    os: String
+    formatted: String!
+  }
+
+  type GeoLocation {
+    city: String
+    country: String
+    countryCode: String
+    formatted: String!
+  }
+
+  extend type Query {
+    parseUserAgent(userAgent: String!): ParsedUserAgent!
+    geolocateIP(ip: String!): GeoLocation
+  }
+`

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -9,6 +9,7 @@ import { createGatewayServer } from './server'
 import { env, scopedEndpoints } from './config'
 import { initAuth, getK8sServer } from './auth'
 import { initializeGateway } from './runtime'
+import { initGeolocation } from './services/geolocation'
 import { log } from '@/shared/utils'
 
 const main = async () => {
@@ -19,6 +20,20 @@ const main = async () => {
     const message = error instanceof Error ? error.message : String(error)
     log.error('Failed to initialize K8s auth', { error: message })
     process.exit(1)
+  }
+
+  // Initialize MaxMind geolocation database (optional)
+  if (env.maxmindDbPath) {
+    try {
+      await initGeolocation(env.maxmindDbPath)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      log.warn('Failed to load MaxMind database, geolocation will be unavailable', {
+        error: message,
+      })
+    }
+  } else {
+    log.info('MAXMIND_DB_PATH not set, geolocation lookups will be unavailable')
   }
 
   // Initialize gateway: compose supergraph eagerly + start background polling

--- a/src/gateway/runtime/compose-worker-bootstrap.mjs
+++ b/src/gateway/runtime/compose-worker-bootstrap.mjs
@@ -1,0 +1,7 @@
+// Dev-only bootstrap. Registers the tsx loader inside the worker thread so the
+// `.ts` entry can be loaded. In production the worker is built to `.js` and
+// this bootstrap is unused.
+import { register } from 'tsx/esm/api'
+
+register()
+await import('./compose-worker.ts')

--- a/src/gateway/runtime/index.ts
+++ b/src/gateway/runtime/index.ts
@@ -6,7 +6,7 @@ import { env } from '@/gateway/config'
 import { getMTLSConfig } from '@/gateway/auth'
 import { log } from '@/shared/utils'
 import { usePrometheusMetrics } from '@/gateway/metrics/metrics'
-import { additionalTypeDefs, additionalResolvers } from '@/gateway/graphql'
+import { useGatewayLocalSchema } from '@/gateway/graphql'
 
 /** Cached supergraph SDL - updated by the worker after each composition cycle */
 let supergraphSdl: string = ''
@@ -43,7 +43,7 @@ let pendingReject: ((err: Error) => void) | null = null
 const resolveWorkerPath = (): { url: URL; execArgv: string[] } => {
   const isDev = new URL(import.meta.url).pathname.endsWith('.ts')
   return isDev
-    ? { url: new URL('./compose-worker.ts', import.meta.url), execArgv: ['--import', 'tsx'] }
+    ? { url: new URL('./compose-worker-bootstrap.mjs', import.meta.url), execArgv: [] }
     : { url: new URL('./compose-worker.js', import.meta.url), execArgv: [] }
 }
 
@@ -187,12 +187,14 @@ export const gateway = createGatewayRuntime({
   supergraph: getSupergraph,
   logging: env.logLevel,
   unifiedGraphHandler,
-  additionalTypeDefs,
-  additionalResolvers,
   plugins: (ctx) => [
     // Uses the SDK configured in telemetry/telemetry.ts via openTelemetrySetup
     useOpenTelemetry({}),
     // Uses the SDK configured in metrics/metrics.ts via usePrometheusMetrics
     usePrometheusMetrics(ctx),
+    // Adds gateway-local fields (parseUserAgent, geolocateIP) to the schema.
+    // Required because @graphql-hive/router-runtime ignores additionalTypeDefs
+    // / additionalResolvers — see ./plugin.ts.
+    useGatewayLocalSchema(),
   ],
 })

--- a/src/gateway/runtime/index.ts
+++ b/src/gateway/runtime/index.ts
@@ -6,6 +6,7 @@ import { env } from '@/gateway/config'
 import { getMTLSConfig } from '@/gateway/auth'
 import { log } from '@/shared/utils'
 import { usePrometheusMetrics } from '@/gateway/metrics/metrics'
+import { additionalTypeDefs, additionalResolvers } from '@/gateway/graphql'
 
 /** Cached supergraph SDL - updated by the worker after each composition cycle */
 let supergraphSdl: string = ''
@@ -186,6 +187,8 @@ export const gateway = createGatewayRuntime({
   supergraph: getSupergraph,
   logging: env.logLevel,
   unifiedGraphHandler,
+  additionalTypeDefs,
+  additionalResolvers,
   plugins: (ctx) => [
     // Uses the SDK configured in telemetry/telemetry.ts via openTelemetrySetup
     useOpenTelemetry({}),

--- a/src/gateway/services/geolocation.ts
+++ b/src/gateway/services/geolocation.ts
@@ -1,0 +1,52 @@
+import { Reader } from '@maxmind/geoip2-node'
+import type ReaderModel from '@maxmind/geoip2-node/dist/src/readerModel'
+import { log } from '@/shared/utils'
+
+export type GeoLocation = {
+  city: string | null
+  country: string | null
+  countryCode: string | null
+  formatted: string
+}
+
+let reader: ReaderModel | null = null
+
+export async function initGeolocation(dbPath: string): Promise<void> {
+  reader = await Reader.open(dbPath)
+  log.info('MaxMind GeoIP database loaded', { path: dbPath })
+}
+
+export function isGeolocationReady(): boolean {
+  return reader !== null
+}
+
+export function lookupIp(ipAddress: string): GeoLocation | null {
+  if (!reader) {
+    log.warn('MaxMind reader not initialized, skipping geolocation lookup')
+    return null
+  }
+
+  try {
+    const result = reader.city(ipAddress)
+    const city = result.city?.names?.en ?? null
+    const country = result.country?.names?.en ?? null
+    const countryCode = result.country?.isoCode ?? null
+
+    let formatted = 'Unknown'
+    if (city && country) {
+      formatted = `${city}, ${country}`
+    } else if (country) {
+      formatted = country
+    } else if (city) {
+      formatted = city
+    }
+
+    return { city, country, countryCode, formatted }
+  } catch (error) {
+    log.warn('GeoIP lookup failed', {
+      ipAddress,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
+  }
+}

--- a/src/gateway/services/user-agent.ts
+++ b/src/gateway/services/user-agent.ts
@@ -1,0 +1,30 @@
+import { UAParser } from 'ua-parser-js'
+
+export type ParsedUserAgent = {
+  browser: string | null
+  os: string | null
+  formatted: string
+}
+
+const OS_DISPLAY_NAMES: Record<string, string> = {
+  'Mac OS': 'macOS',
+  'Chrome OS': 'ChromeOS',
+}
+
+export function parseUserAgent(userAgent: string): ParsedUserAgent {
+  const result = UAParser(userAgent)
+  const browser = result.browser.name ?? null
+  const rawOs = result.os.name ?? null
+  const os = rawOs ? (OS_DISPLAY_NAMES[rawOs] ?? rawOs) : null
+
+  let formatted = 'Unknown'
+  if (browser && os) {
+    formatted = `${browser} (${os})`
+  } else if (browser) {
+    formatted = browser
+  } else if (os) {
+    formatted = os
+  }
+
+  return { browser, os, formatted }
+}


### PR DESCRIPTION
## Summary
- Adds two GraphQL queries (`parseUserAgent`, `geolocateIP`) on the federated supergraph that any in-cluster client can call to enrich session metadata.
- Loads a MaxMind GeoLite2-City database at startup from `MAXMIND_DB_PATH`; missing/unreadable DB logs a warning and `geolocateIP` returns null instead of failing requests.
- Wires `additionalTypeDefs` and `additionalResolvers` into `createGatewayRuntime` so the new types compose into the existing OpenAPI-derived supergraph.

## Why
`auth-provider-zitadel` returns sessions with raw IP and User-Agent. Both need to be enriched (geolocation + parsed browser/OS) before reaching end-user clients. Putting the enrichment in the gateway avoids pulling MaxMind and `ua-parser-js` dependencies into every backend service that exposes session-like data, and gives every internal caller a single canonical path. The auth provider calls these two resolvers in-cluster on each session list/get.

## Companion changes
- `datum-cloud/auth-provider-zitadel#81` — calls these resolvers from the sessions REST handler.
- `datum-cloud/milo#534` — adds `Location`, `Browser`, `OS` fields to `SessionStatus` so the enriched values can be returned.
- `datum-cloud/infra` PR (this branch) — adds the `geoipupdate` initContainer + sidecar that keep the `.mmdb` fresh and the `graphql-gateway-maxmind` ExternalSecret with the license key.

<img width="784" height="76" alt="Screenshot 2026-04-28 at 17 11 41" src="https://github.com/user-attachments/assets/b6e644ca-d229-472d-a2aa-d199820f191c" />
<img width="778" height="79" alt="Screenshot 2026-04-28 at 17 12 50" src="https://github.com/user-attachments/assets/8f93725b-05b3-494f-8b13-194498a12e52" />
