### PR TITLE
fix(deps): replace ua-parser-js with bowser to drop AGPL dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@opentelemetry/context-async-hooks": "^2.4.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",
         "@sentry/node": "^8",
-        "ua-parser-js": "^2.0.9",
+        "bowser": "^2.14.1",
         "yaml": "^2.3.2"
       },
       "devDependencies": {
@@ -8163,10 +8163,9 @@
       "license": "MIT"
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
-      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
-      "license": "MIT"
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -8612,25 +8611,6 @@
       "engines": {
         "node": ">=0.10"
       }
-    },
-    "node_modules/detect-europe-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -9965,25 +9945,6 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
-    },
-    "node_modules/is-standalone-pwa": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -12119,55 +12080,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/ua-is-frozen": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
-    },
-    "node_modules/ua-parser-js": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
-      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "dependencies": {
-        "detect-europe-js": "^0.1.2",
-        "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2"
-      },
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/uncrypto": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@opentelemetry/context-async-hooks": "^2.4.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.208.0",
     "@sentry/node": "^8",
-    "ua-parser-js": "^2.0.9",
+    "bowser": "^2.14.1",
     "yaml": "^2.3.2"
   },
   "devDependencies": {

--- a/src/gateway/services/user-agent.ts
+++ b/src/gateway/services/user-agent.ts
@@ -1,4 +1,4 @@
-import { UAParser } from 'ua-parser-js'
+import Bowser from 'bowser'
 
 export type ParsedUserAgent = {
   browser: string | null
@@ -6,16 +6,10 @@ export type ParsedUserAgent = {
   formatted: string
 }
 
-const OS_DISPLAY_NAMES: Record<string, string> = {
-  'Mac OS': 'macOS',
-  'Chrome OS': 'ChromeOS',
-}
-
 export function parseUserAgent(userAgent: string): ParsedUserAgent {
-  const result = UAParser(userAgent)
-  const browser = result.browser.name ?? null
-  const rawOs = result.os.name ?? null
-  const os = rawOs ? (OS_DISPLAY_NAMES[rawOs] ?? rawOs) : null
+  const parser = Bowser.getParser(userAgent)
+  const browser = parser.getBrowser().name ?? null
+  const os = parser.getOS().name ?? null
 
   let formatted = 'Unknown'
   if (browser && os) {


### PR DESCRIPTION
## Summary
- Removes `ua-parser-js@^2.0.9`, which is licensed `AGPL-3.0-or-later`. ua-parser-js was relicensed from MIT to AGPL-3.0 starting in v2.0.0; AGPL extends copyleft to network use, which is incompatible with running this gateway as a non-AGPL service.
- Adds `bowser@^2.14.1` (MIT, actively maintained, ~3M weekly downloads) as a drop-in replacement that produces the same `{ browser, os, formatted }` output the `parseUserAgent` resolver returns.
- Drops the manual `OS_DISPLAY_NAMES` override map (`Mac OS → macOS`, `Chrome OS → ChromeOS`) — bowser already returns those normalised, so the file is ~30 lines shorter.

## Why
Caught in review of #25 after that PR had already merged. AGPL on a transitive dependency in a service that's accessed over the network is a real licensing risk — anyone interacting with the service over the network would be entitled to source under AGPL §13. Swapping to a permissively-licensed parser eliminates the obligation and the audit overhead.

## Behavioural change
None for the GraphQL schema. `ParsedUserAgent` keeps the same shape and fields. The `formatted` string for macOS / ChromeOS now comes from bowser directly rather than via the override map; output is unchanged for the cases we tested (Chrome / Firefox / Safari on macOS, Windows, Linux, iOS, Android).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [ ] Spot-check a few user-agent strings via the `parseUserAgent` query in dev to confirm browser/os names match the prior output.