### PR TITLE
fix: have sessions/deleteSession bypass mTLS so the user token wins authn

### DIFF
--- a/src/gateway/auth/index.ts
+++ b/src/gateway/auth/index.ts
@@ -8,6 +8,11 @@ let k8sServer: string | null = null
 let mtlsFetch: typeof fetch | null = null
 let mtlsConfig: K8sMTLSConfig | null = null
 let initialized = false
+// Saved before the global fetch override so callers that explicitly want to
+// bypass mTLS (e.g. the local sessions resolver, which needs milo to
+// authenticate the *end user* via bearer token rather than the gateway via
+// client cert) can still reach the K8s server with a plain fetch.
+let savedOriginalFetch: typeof fetch | null = null
 
 /**
  * Initialize K8s authentication by loading mTLS credentials from kubeconfig.
@@ -33,7 +38,7 @@ export function initAuth(): void {
   mtlsFetch = createMTLSFetch(mtlsConfig)
 
   // Override global fetch to use mTLS for requests to the K8s API server
-  const originalFetch = globalThis.fetch
+  savedOriginalFetch = globalThis.fetch
   globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
 
@@ -42,7 +47,7 @@ export function initAuth(): void {
       return mtlsFetch!(input, init)
     }
 
-    return originalFetch(input, init)
+    return savedOriginalFetch!(input, init)
   }) as typeof fetch
 
   initialized = true
@@ -81,6 +86,27 @@ export function getMTLSConfig(): K8sMTLSConfig {
     throw new Error('K8s auth not initialized. Call initAuth() first.')
   }
   return mtlsConfig
+}
+
+/**
+ * Get the pre-override fetch for callers that need to reach the K8s API
+ * server WITHOUT presenting the gateway's client cert.
+ *
+ * The default global fetch routes K8s-bound requests through the mTLS agent,
+ * which means K8s authenticates the request as the gateway's identity. For
+ * user-scoped paths that need milo to authenticate the *end user* via the
+ * forwarded bearer token, callers must use this fetch instead so no client
+ * cert is presented and the bearer-token authenticator wins.
+ *
+ * Node's TLS still validates milo's server cert via NODE_EXTRA_CA_CERTS.
+ *
+ * @throws Error if auth not initialized
+ */
+export function getOriginalFetch(): typeof fetch {
+  if (!savedOriginalFetch) {
+    throw new Error('K8s auth not initialized. Call initAuth() first.')
+  }
+  return savedOriginalFetch
 }
 
 /**

--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { GraphQLError } from 'graphql'
 
+// Resolvers call getOriginalFetch() to bypass the global mTLS-wrapped fetch.
+// Mock it to return whatever globalThis.fetch is at call-time so the existing
+// vi.stubGlobal('fetch', spy) plumbing in each describe block continues to
+// work without the test having to thread a mock through the auth module.
 vi.mock('@/gateway/auth', () => ({
   getK8sServer: () => 'https://k8s.test',
+  getOriginalFetch: () => globalThis.fetch,
 }))
 
 vi.mock('@/gateway/services/geolocation', () => ({

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql'
 import { parseUserAgent } from '@/gateway/services/user-agent'
 import { lookupIp } from '@/gateway/services/geolocation'
-import { getK8sServer } from '@/gateway/auth'
+import { getK8sServer, getOriginalFetch } from '@/gateway/auth'
 import { log } from '@/shared/utils'
 
 /**
@@ -85,7 +85,11 @@ export const additionalResolvers = {
         const url = sessionsURL(context)
         const authorization = getHeader(context, 'authorization')
 
-        const response = await fetch(url, {
+        // Use the pre-override fetch so no client cert is presented. milo's
+        // user-scoped path needs to authenticate the *end user* via bearer
+        // token; with the gateway's mTLS cert in the way, X509 auth wins
+        // first and the user-scoped RBAC check 403s.
+        const response = await getOriginalFetch()(url, {
           headers: {
             ...(authorization ? { Authorization: authorization } : {}),
             Accept: 'application/json',
@@ -121,7 +125,10 @@ export const additionalResolvers = {
       const url = sessionsURL(context, args.id)
       const authorization = getHeader(context, 'authorization')
 
-      const response = await fetch(url, {
+      // Same reason as Query.sessions — bypass the mTLS-wrapped global
+      // fetch so milo authenticates the user via bearer token rather than
+      // the gateway's client cert.
+      const response = await getOriginalFetch()(url, {
         method: 'DELETE',
         headers: {
           ...(authorization ? { Authorization: authorization } : {}),


### PR DESCRIPTION
## Summary
- Saves the pre-override fetch in `src/gateway/auth/index.ts` and exposes it via `getOriginalFetch()`.
- Switches the `Query.sessions` and `Mutation.deleteSession` resolvers to call milo through that fetch so no client cert is presented.

## Why
The deployed gateway is hitting milo's user-scoped sessions path with 403 even though the bearer token is being forwarded:

```
[INFO] Scoped request: user/349403784142655761
[WARN] milo sessions fetch failed {"status":403,"hasAuthorization":true,
  "url":"https://milo-apiserver.datum-system.svc.cluster.local:6443/apis/iam.miloapis.com/v1alpha1/users/349403784142655761/control-plane/apis/identity.miloapis.com/v1alpha1/sessions"}
```

`initAuth()` overrides `globalThis.fetch` to wrap any K8s-bound URL in the gateway's mTLS client cert. K8s's authn chain runs in order — X509 client-cert auth succeeds first and wins, so milo identifies the request as the **gateway's** system identity instead of the end user. The user-scoped `/control-plane` path then 403s because the gateway doesn't own those user-scoped sessions.

Cloud-portal's REST flow doesn't hit this because it never presents a client cert — bearer-token auth is the only authenticator that succeeds, so milo authenticates the actual user and the user-scoped path resolves correctly. We need the same property here.

## Fix
`getOriginalFetch()` returns the fetch that was in place before the override. The two resolvers that call milo on behalf of an end user (`sessions`, `deleteSession`) now use it explicitly. Node's TLS still validates milo's server cert via `NODE_EXTRA_CA_CERTS`; the only thing that changes is that no *client* cert is sent.

The `parseUserAgent` and `geolocateIP` resolvers don't talk to milo, so they're unaffected. The federated org/proj resolvers in `compose-worker.ts` keep the mTLS path — that flow already works.

## Test plan
- [x] `npm run test` — 30/30 passing.
- [x] `npx tsc --noEmit`, `npm run build`, `npm run lint` clean.
- [ ] After deploy: `query { sessions { id ipAddress location { formatted } userAgent { formatted } } }` from cloud-portal returns the caller's sessions instead of `[]` from the gateway's 403-then-empty fallback.