### PR TITLE
fix: route user-scoped milo calls through public ingress

### DIFF
--- a/src/gateway/config/env.ts
+++ b/src/gateway/config/env.ts
@@ -49,4 +49,20 @@ export const env = {
 
   /** Path to the MaxMind GeoLite2-City.mmdb database file */
   maxmindDbPath: process.env.MAXMIND_DB_PATH || '',
+
+  /**
+   * Public-facing milo API URL (e.g. https://api.staging.env.datum.net).
+   *
+   * The gateway's mTLS upstream (DATUM_BASE_URL / kubeconfig server) is the
+   * raw in-cluster apiserver. Some milo paths — notably the user-scoped
+   * /control-plane/.../sessions/{id} delete — only authorize correctly when
+   * the request comes through the public Envoy ingress that fronts milo,
+   * because that ingress translates user identity in a way the bare
+   * apiserver does not. Hand-written resolvers that act on behalf of an
+   * end user must call this URL instead of getK8sServer().
+   *
+   * Falls back to getK8sServer() when unset so dev / unit-test paths keep
+   * working without extra config.
+   */
+  datumApiUrl: process.env.DATUM_API_URL || '',
 }

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -2,6 +2,7 @@ import { GraphQLError } from 'graphql'
 import { parseUserAgent } from '@/gateway/services/user-agent'
 import { lookupIp } from '@/gateway/services/geolocation'
 import { getK8sServer, getOriginalFetch } from '@/gateway/auth'
+import { env } from '@/gateway/config'
 import { log } from '@/shared/utils'
 
 /**
@@ -64,7 +65,12 @@ function enrichSession(session: UpstreamSession) {
 }
 
 function sessionsURL(context: ResolverContext, name?: string) {
-  const server = getK8sServer()
+  // Prefer the public ingress URL when configured. The user-scoped
+  // /control-plane paths only authorize correctly through that ingress;
+  // the raw in-cluster apiserver 403s on cluster-scoped sessions.delete
+  // even with a valid bearer token. Fallback to the kubeconfig server so
+  // dev environments without the env var still work.
+  const server = env.datumApiUrl || getK8sServer()
   const endpointPrefix = getHeader(context, 'x-resource-endpoint-prefix')
   const base = `${server}${endpointPrefix}/apis/identity.miloapis.com/v1alpha1/sessions`
   return name ? `${base}/${encodeURIComponent(name)}` : base


### PR DESCRIPTION
## Summary
- Adds `DATUM_API_URL` env var (`env.datumApiUrl`) for the public-facing milo URL (e.g. `https://api.staging.env.datum.net`).
- Uses it as the base for the `sessions` and `deleteSession` resolvers when set; falls back to `getK8sServer()` otherwise so dev / unit-test paths still work.

## Why
The gateway's `Mutation.deleteSession` is 403ing on staging:

```
[WARN] milo deleteSession failed
{"status":403,"hasAuthorization":true,"detail":"... User \"mjenkinson@datum.net\"
  cannot delete resource \"sessions\" in API group \"identity.miloapis.com\"
  at the cluster scope ..."}
```

Cloud-portal's REST `revokeUserActiveSession` flow hits **the same URL shape** and works in staging and prod. The difference:

- **REST** goes through `app/server/routes/proxy.ts:55`, which targets `${env.public.apiUrl}` — `https://api.staging.env.datum.net`. That's the **public** ingress, fronted by Envoy + an auth-translation layer that produces an identity milo's RBAC accepts.
- **Gateway** uses `getK8sServer()`, which is the raw in-cluster apiserver from kubeconfig. No translation layer; cluster-scoped sessions.delete fails RBAC.

So the gateway needs to hit the same URL the REST proxy does. The federated mesh resolvers in `compose-worker.ts` keep using the in-cluster URL via mTLS — that path is authorized by the federated runtime and isn't affected.

## Test plan
- [x] `npm run test` (30/30), `tsc --noEmit`, `build`, `lint` all clean.
- [ ] Companion infra PR sets `DATUM_API_URL=https://api.staging.env.datum.net` (and prod equivalent) on the gateway Deployment.
- [ ] After deploy: `Mutation.deleteSession` succeeds for the caller's own session id; the active-sessions page's Revoke action works end-to-end.

## Companion PR
infra repo — sets `DATUM_API_URL` on the gateway Deployment for staging and prod.