### PR TITLE
security: override protobufjs to ^7.5.5 to patch CVE-2026-41242

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,31 +35,6 @@
         "vitest": "^2.1.9"
       }
     },
-    "node_modules/@apollo/protobufjs": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.7.tgz",
-      "integrity": "sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "apollo-pbjs": "bin/pbjs",
-        "apollo-pbts": "bin/pbts"
-      }
-    },
     "node_modules/@apollo/server-gateway-interface": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-2.0.0.tgz",
@@ -83,6 +58,35 @@
       "dependencies": {
         "@apollo/protobufjs": "1.2.7"
       }
+    },
+    "node_modules/@apollo/usage-reporting-protobuf/node_modules/@apollo/protobufjs": {
+      "name": "protobufjs",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@apollo/usage-reporting-protobuf/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
     },
     "node_modules/@apollo/utils.dropunuseddefinitions": {
       "version": "2.0.1",
@@ -5847,10 +5851,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
@@ -5875,10 +5878,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
@@ -5893,10 +5895,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="
     },
     "node_modules/@repeaterjs/repeater": {
       "version": "3.0.6",
@@ -7621,12 +7622,6 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
     },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
@@ -10989,12 +10984,6 @@
       "integrity": "sha512-sVN2zimthq7aZ5sPGXnSz32rZPuqcparVW50chJQe+mzTYV+IsxSsl/2gnkWWE2Of7K3myBQBqtLKOUEHJKRsQ==",
       "license": "MIT"
     },
-    "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -11741,22 +11730,21 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
     "typescript": "^5.3.0",
     "typescript-eslint": "^8.48.1",
     "vitest": "^2.1.9"
+  },
+  "overrides": {
+    "@apollo/protobufjs": "npm:protobufjs@^7.5.5",
+    "protobufjs": "^7.5.5"
   }
 }


### PR DESCRIPTION
## Summary

- Snyk flagged `@apollo/protobufjs@1.2.7` for [CVE-2026-41242](https://nvd.nist.gov/vuln/detail/CVE-2026-41242) — a critical (CVSS 9.8) arbitrary code injection in `protobufjs` versions `<7.5.5`, exploitable via the `Type.name` field of attacker-supplied protobuf definitions.
- The Apollo fork (`@apollo/protobufjs`) is unmaintained and has no fixed version, so this PR adds an `npm` `overrides` block redirecting it to upstream `protobufjs@^7.5.5` (the API is identical — Apollo's package is a straight fork).
- Also pins all transitive `protobufjs` to `^7.5.5` to bump the `7.5.4` copy pulled in by `@grpc/proto-loader` (used by `@opentelemetry/exporter-trace-otlp-grpc`), since the same CVE affects it.

### Dependency chain that pulled in the vulnerable version

```
@graphql-hive/gateway → @graphql-hive/gateway-runtime
  → @graphql-yoga/plugin-apollo-usage-report
    → @apollo/usage-reporting-protobuf@4.1.1
      → @apollo/protobufjs@1.2.7   ← vulnerable
```

Note: the `apollo-usage-report` plugin is loaded transitively but is **not actually configured** in this gateway (no references in `src/`), so the vulnerable code path was not reachable at runtime. This change clears the Snyk alert and hardens the dependency tree regardless.

### After override

```
@apollo/protobufjs           → protobufjs@7.5.6 (overridden)
@grpc/proto-loader           → protobufjs@7.5.6
@opentelemetry/otlp-transformer → protobufjs@7.5.6 (overridden)
```

`npm audit` critical count: 2 → 1.

## Test plan

- [x] `npm install` succeeds and `package-lock.json` resolves all `protobufjs` to `7.5.6`
- [x] `npm run build` (esbuild) — clean
- [x] `npm test` — all 30 tests pass
- [x] Verified `@apollo/protobufjs/minimal` subpath resolves correctly via the npm alias
- [x] `Report.create() → encode → decode` round-trip through `@apollo/usage-reporting-protobuf` works
- [x] `@grpc/proto-loader.loadSync(...)` parses a proto file on `protobufjs@7.5.6`
- [x] `OTLPTraceExporter` constructs OK
- [ ] Reviewer to confirm Snyk alert clears once this lands on `main`

## Rollback

Delete the `overrides` block from `package.json` and run `npm install`. No source-code changes to revert.

Made with [Cursor](https://cursor.com)