### PR TITLE
feat(sessions): accept optional userID arg for cross-user lookups

### DIFF
--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -54,8 +54,10 @@ const jsonResponse = (body: unknown, status = 200) =>
     headers: { 'content-type': 'application/json' },
   })
 
-const callSessions = (context: ReturnType<typeof ctx> = ctx()) =>
-  (additionalResolvers.Query!.sessions as SessionsResolver)(null, null, context)
+const callSessions = (
+  args: { userID?: string } = {},
+  context: ReturnType<typeof ctx> = ctx()
+) => (additionalResolvers.Query!.sessions as SessionsResolver)(null, args, context)
 
 const callDeleteSession = (
   args: { id: string },
@@ -94,7 +96,7 @@ describe('Query.sessions', () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ items: [] }))
     await (additionalResolvers.Query!.sessions as SessionsResolver)(
       null,
-      null,
+      {},
       yogaCtx({ 'x-resource-endpoint-prefix': '/apis/iam.miloapis.com/v1alpha1/users/u1/control-plane' }) as Parameters<SessionsResolver>[2]
     )
 
@@ -111,7 +113,7 @@ describe('Query.sessions', () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ items: [] }))
     await (additionalResolvers.Query!.sessions as SessionsResolver)(
       null,
-      null,
+      {},
       { headers: {} } as Parameters<SessionsResolver>[2]
     )
 
@@ -123,11 +125,21 @@ describe('Query.sessions', () => {
 
   it('honours x-resource-endpoint-prefix when present', async () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse({ items: [] }))
-    await callSessions(ctx({ 'x-resource-endpoint-prefix': '/projects/p1' }))
+    await callSessions({}, ctx({ 'x-resource-endpoint-prefix': '/projects/p1' }))
 
     const [url] = fetchSpy.mock.calls[0]
     expect(url).toBe(
       'https://k8s.test/projects/p1/apis/identity.miloapis.com/v1alpha1/sessions'
+    )
+  })
+
+  it('forwards userID as a status.userUID field selector', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ items: [] }))
+    await callSessions({ userID: 'target-user' })
+
+    const [url] = fetchSpy.mock.calls[0]
+    expect(url).toBe(
+      'https://k8s.test/apis/identity.miloapis.com/v1alpha1/sessions?fieldSelector=status.userUID%3Dtarget-user'
     )
   })
 

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -63,11 +63,21 @@ function enrichSession(session: UpstreamSession) {
   }
 }
 
-function sessionsURL(context: ResolverContext, name?: string) {
+function sessionsURL(
+  context: ResolverContext,
+  options: { name?: string; userID?: string } = {}
+) {
   const server = getK8sServer()
   const endpointPrefix = getHeader(context, 'x-resource-endpoint-prefix')
   const base = `${server}${endpointPrefix}/apis/identity.miloapis.com/v1alpha1/sessions`
-  return name ? `${base}/${encodeURIComponent(name)}` : base
+  if (options.name) return `${base}/${encodeURIComponent(options.name)}`
+  if (options.userID) {
+    const params = new URLSearchParams({
+      fieldSelector: `status.userUID=${options.userID}`,
+    })
+    return `${base}?${params.toString()}`
+  }
+  return base
 }
 
 export const additionalResolvers = {
@@ -80,9 +90,13 @@ export const additionalResolvers = {
       return lookupIp(args.ip)
     },
 
-    sessions: async (_root: unknown, _args: unknown, context: ResolverContext) => {
+    sessions: async (
+      _root: unknown,
+      args: { userID?: string },
+      context: ResolverContext
+    ) => {
       try {
-        const url = sessionsURL(context)
+        const url = sessionsURL(context, { userID: args.userID })
         const authorization = getHeader(context, 'authorization')
 
         // Use the pre-override fetch so no client cert is presented. milo's
@@ -122,7 +136,7 @@ export const additionalResolvers = {
       args: { id: string },
       context: ResolverContext
     ) => {
-      const url = sessionsURL(context, args.id)
+      const url = sessionsURL(context, { name: args.id })
       const authorization = getHeader(context, 'authorization')
 
       // Same reason as Query.sessions — bypass the mTLS-wrapped global

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -27,7 +27,16 @@ export const additionalTypeDefs = /* GraphQL */ `
   extend type Query {
     parseUserAgent(userAgent: String!): ParsedUserAgent!
     geolocateIP(ip: String!): GeoLocation
-    sessions: [ExtendedSession!]!
+    """
+    Returns sessions for the authenticated caller by default.
+
+    When userID is provided and differs from the caller, the request is
+    forwarded to milo with a status.userUID field selector. milo authorizes
+    the cross-user lookup via SubjectAccessReview against
+    iam.miloapis.com/users/<userID> — callers without that permission get
+    an empty list (the underlying 403 is logged).
+    """
+    sessions(userID: ID): [ExtendedSession!]!
   }
 
   extend type Mutation {


### PR DESCRIPTION
## Summary

Extends the local `Query.sessions` resolver with an optional `userID` argument. When provided and different from the authenticated caller, the request is forwarded to milo with a `status.userUID=<userID>` field selector; milo authorizes the cross-user lookup via `SubjectAccessReview` against `iam.miloapis.com/users/<userID>`.

Self-service usage (omitting the arg) is unchanged — backwards-compatible.

## Why

The staff portal's user detail page wants to surface a target user's active sessions enriched with the same parsed user-agent + geolocation that cloud-portal already gets for self-service. The K8s aggregated API now supports cross-user listing (auth-provider-zitadel#69), but the `parseUserAgent` / `geolocateIP` enrichment lives in this gateway. Adding `userID` here lets staff-portal call one query and get fully-enriched cross-user sessions.

## Authorization

The gateway is a thin forwarder — authz stays in milo. Composes with the existing `iam.miloapis.com/users` RBAC: staff/admin roles that grant `get users` cluster-wide automatically work; users without that permission get an empty list (the underlying 403 is logged, not surfaced).

`Mutation.deleteSession` is unchanged. Delete remains self-only at the milo layer; revisit if/when staff need to revoke other users' sessions.

## Test plan
- [x] `bun run test` — all 31 vitest tests pass, including the new field-selector test
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [ ] Verify in staging that staff-portal returns the correct user's sessions once the auth-provider-zitadel update with `UserIdentity` field-selector registration (datum-cloud/zitadel-provider#108) and the `iam.miloapis.com/users.get` PolicyBinding for `staff-users` are in place

Refs auth-provider-zitadel#69, zitadel-provider#108