### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,7 @@ jobs:
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.9.0
     with:
       image-name: graphql-gateway
+      registry-organization: milo-os
     secrets: inherit
 
   publish-kustomize-bundles:
@@ -24,8 +25,8 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.9.0
     with:
-      bundle-name: ghcr.io/datum-cloud/graphql-gateway-kustomize
+      bundle-name: ghcr.io/milo-os/graphql-gateway-kustomize
       bundle-path: config
       image-overlays: config/base
-      image-name: ghcr.io/datum-cloud/graphql-gateway
+      image-name: ghcr.io/milo-os/graphql-gateway
     secrets: inherit

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: graphql-gateway
-          image: ghcr.io/datum-cloud/graphql-gateway:latest
+          image: ghcr.io/milo-os/graphql-gateway:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 4000

--- a/config/components/observability/alerts/subgraph-errors.yaml
+++ b/config/components/observability/alerts/subgraph-errors.yaml
@@ -21,7 +21,7 @@ spec:
               execute requests against subgraph {{ $labels.subgraphName }}.
               This typically indicates a TLS certificate issue or the
               downstream API server being unreachable.
-            runbook_url: "https://github.com/datum-cloud/graphql-gateway/blob/main/docs/runbooks/subgraph-errors.md"
+            runbook_url: "https://github.com/milo-os/graphql-gateway/blob/main/docs/runbooks/subgraph-errors.md"
         - alert: GraphQLGatewaySubgraphErrorsSustained
           expr: |
             increase(graphql_gateway_subgraph_execute_errors[15m]) > 5
@@ -38,4 +38,4 @@ spec:
               over 10 minutes. Users are likely unable to load
               organization memberships or other data served by this
               subgraph.
-            runbook_url: "https://github.com/datum-cloud/graphql-gateway/blob/main/docs/runbooks/subgraph-errors.md"
+            runbook_url: "https://github.com/milo-os/graphql-gateway/blob/main/docs/runbooks/subgraph-errors.md"


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.