### PR TITLE
feat: add User CRUD operations to GraphQL gateway

### DIFF
--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -795,7 +795,7 @@ describe('Query.projectQuotaBuckets', () => {
     fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
     const result = await (additionalResolvers.Query!.projectQuotaBuckets as (r: null, a: { projectName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { projectName: 'my-proj' }, ctx()) as { items: unknown[] }
     expect(result.items).toEqual([])
-    const urls: string[] = fetchSpy.mock.calls.map((c: [string]) => c[0])
+    const urls: string[] = fetchSpy.mock.calls.map((c: unknown[]) => c[0] as string)
     expect(urls.some((u) => u.includes('/projects/my-proj/control-plane'))).toBe(true)
   })
 })
@@ -862,7 +862,7 @@ describe('Query.projectQuotaGrants', () => {
     fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
     const result = await (additionalResolvers.Query!.projectQuotaGrants as (r: null, a: { projectName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { projectName: 'my-proj' }, ctx()) as { items: unknown[] }
     expect(result.items).toEqual([])
-    const urls: string[] = fetchSpy.mock.calls.map((c: [string]) => c[0])
+    const urls: string[] = fetchSpy.mock.calls.map((c: unknown[]) => c[0] as string)
     expect(urls.some((u) => u.includes('/projects/my-proj/control-plane'))).toBe(true)
   })
 })

--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -704,3 +704,165 @@ describe('Query.parseUserAgent and Query.geolocateIP', () => {
     })
   })
 })
+
+// ─── Quota resolvers ──────────────────────────────────────────────────────────
+
+const mockBucket = (resourceType: string, overrides: Record<string, unknown> = {}) => ({
+  metadata: { name: `bucket-${resourceType}`, namespace: 'organization-acme' },
+  spec: {
+    resourceType,
+    consumerRef: { apiGroup: 'resourcemanager.miloapis.com', kind: 'Organization', name: 'acme' },
+  },
+  status: { allocated: 3, limit: 10, available: 7 },
+  ...overrides,
+})
+
+const mockRegistration = (resourceType: string, overrides: Record<string, unknown> = {}) => ({
+  metadata: {
+    name: `reg-${resourceType}`,
+    annotations: { 'kubernetes.io/display-name': `Display ${resourceType}`, 'kubernetes.io/description': `Desc ${resourceType}` },
+    labels: { 'services.miloapis.com/owner': 'core.miloapis.com' },
+  },
+  spec: { resourceType, type: 'Allocation' },
+  ...overrides,
+})
+
+describe('Query.orgQuotaBuckets', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  afterEach(() => vi.unstubAllGlobals())
+
+  const call = (orgName: string) =>
+    (additionalResolvers.Query!.orgQuotaBuckets as (r: null, a: { orgName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { orgName }, ctx())
+
+  it('joins buckets with registrations and resolves display names', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('allowancebuckets'))
+        return Promise.resolve(jsonResponse({ items: [mockBucket('core.miloapis.com/quotas')] }))
+      return Promise.resolve(jsonResponse({ items: [mockRegistration('core.miloapis.com/quotas')] }))
+    })
+    const result = await call('acme') as { items: unknown[] }
+    expect(result.items).toHaveLength(1)
+    expect((result.items[0] as Record<string, unknown>).displayName).toBe('Display core.miloapis.com/quotas')
+    expect((result.items[0] as Record<string, unknown>).serviceDisplayName).toBe('Platform Core')
+    expect((result.items[0] as Record<string, unknown>).allocated).toBe(3)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('filters out Feature-type registrations', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('allowancebuckets'))
+        return Promise.resolve(jsonResponse({ items: [mockBucket('some.com/feature')] }))
+      return Promise.resolve(jsonResponse({ items: [{ ...mockRegistration('some.com/feature'), spec: { resourceType: 'some.com/feature', type: 'Feature' } }] }))
+    })
+    const result = await call('acme') as { items: unknown[] }
+    expect(result.items).toHaveLength(0)
+  })
+
+  it('falls back to hardcoded display name when annotation absent', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('allowancebuckets'))
+        return Promise.resolve(jsonResponse({ items: [mockBucket('compute.datumapis.com/instances')] }))
+      return Promise.resolve(jsonResponse({ items: [{ metadata: { name: 'r', annotations: {}, labels: { 'services.miloapis.com/owner': 'compute.datumapis.com' } }, spec: { resourceType: 'compute.datumapis.com/instances', type: 'Allocation' } }] }))
+    })
+    const result = await call('acme') as { items: { displayName: string; serviceDisplayName: string }[] }
+    expect(result.items[0].displayName).toBe('Instances')
+    expect(result.items[0].serviceDisplayName).toBe('Compute')
+  })
+
+  it('returns empty list when buckets fetch fails', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('allowancebuckets')) return Promise.resolve(new Response('{}', { status: 403 }))
+      return Promise.resolve(jsonResponse({ items: [] }))
+    })
+    const result = await call('acme') as { items: unknown[] }
+    expect(result.items).toEqual([])
+  })
+
+  it('returns empty list on network error', async () => {
+    fetchSpy.mockRejectedValue(new Error('network'))
+    const result = await call('acme') as { items: unknown[] }
+    expect(result.items).toEqual([])
+  })
+})
+
+describe('Query.projectQuotaBuckets', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetches from project control plane', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
+    const result = await (additionalResolvers.Query!.projectQuotaBuckets as (r: null, a: { projectName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { projectName: 'my-proj' }, ctx()) as { items: unknown[] }
+    expect(result.items).toEqual([])
+    const urls: string[] = fetchSpy.mock.calls.map((c: [string]) => c[0])
+    expect(urls.some((u) => u.includes('/projects/my-proj/control-plane'))).toBe(true)
+  })
+})
+
+describe('Query.orgQuotaGrants', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  afterEach(() => vi.unstubAllGlobals())
+
+  const call = (orgName: string) =>
+    (additionalResolvers.Query!.orgQuotaGrants as (r: null, a: { orgName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { orgName }, ctx())
+
+  const mockGrant = () => ({
+    metadata: { name: 'grant-1', namespace: 'organization-acme', creationTimestamp: '2024-01-01T00:00:00Z', labels: {} },
+    spec: { allowances: [{ resourceType: 'core.miloapis.com/quotas', buckets: [{ amount: 5 }, { amount: 3 }] }] },
+    status: { conditions: [{ type: 'Active', status: 'True', message: 'ok' }] },
+  })
+
+  it('flattens allowances and resolves display names', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('resourcegrants'))
+        return Promise.resolve(jsonResponse({ items: [mockGrant()] }))
+      return Promise.resolve(jsonResponse({ items: [mockRegistration('core.miloapis.com/quotas')] }))
+    })
+    const result = await call('acme') as { items: { allowances: { resourceType: string; amount: number; displayName: string }[]; autoCreated: boolean; conditions: unknown[] }[] }
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].allowances).toHaveLength(1)
+    expect(result.items[0].allowances[0].amount).toBe(8) // 5 + 3
+    expect(result.items[0].allowances[0].displayName).toBe('Display core.miloapis.com/quotas')
+    expect(result.items[0].autoCreated).toBe(false)
+    expect(result.items[0].conditions).toHaveLength(1)
+  })
+
+  it('marks autoCreated grants', async () => {
+    const autoGrant = {
+      metadata: { name: 'auto-1', namespace: 'organization-acme', labels: { 'quota.miloapis.com/auto-created': 'true' } },
+      spec: { allowances: [] },
+      status: { conditions: [] },
+    }
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('resourcegrants')) return Promise.resolve(jsonResponse({ items: [autoGrant] }))
+      return Promise.resolve(jsonResponse({ items: [] }))
+    })
+    const result = await call('acme') as { items: { autoCreated: boolean }[] }
+    expect(result.items[0].autoCreated).toBe(true)
+  })
+
+  it('returns empty list when grants fetch fails', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('resourcegrants')) return Promise.resolve(new Response('{}', { status: 500 }))
+      return Promise.resolve(jsonResponse({ items: [] }))
+    })
+    const result = await call('acme') as { items: unknown[] }
+    expect(result.items).toEqual([])
+  })
+})
+
+describe('Query.projectQuotaGrants', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetches from project control plane', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
+    const result = await (additionalResolvers.Query!.projectQuotaGrants as (r: null, a: { projectName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { projectName: 'my-proj' }, ctx()) as { items: unknown[] }
+    expect(result.items).toEqual([])
+    const urls: string[] = fetchSpy.mock.calls.map((c: [string]) => c[0])
+    expect(urls.some((u) => u.includes('/projects/my-proj/control-plane'))).toBe(true)
+  })
+})

--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -438,6 +438,252 @@ describe('Query.serviceConsumers', () => {
   })
 })
 
+describe('Query.organizations', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  const callOrganizations = (args: { limit?: number; cursor?: string; search?: string } = {}) =>
+    (additionalResolvers.Query!.organizations as (r: null, a: typeof args, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, args, ctx())
+
+  it('lists organizations and maps displayName from annotation', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            metadata: {
+              name: 'acme',
+              creationTimestamp: '2024-01-01T00:00:00Z',
+              annotations: { 'kubernetes.io/description': 'Acme Corp' },
+            },
+            spec: { type: 'Standard' },
+            status: { conditions: [{ type: 'Ready', status: 'True' }] },
+          },
+        ],
+        metadata: { continue: 'tok123' },
+      })
+    )
+
+    const result = await callOrganizations({ limit: 10 }) as { items: unknown[]; continueToken: string }
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]).toMatchObject({ name: 'acme', displayName: 'Acme Corp', type: 'Standard', state: 'True' })
+    expect(result.continueToken).toBe('tok123')
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/apis/resourcemanager.miloapis.com/v1alpha1/organizations?limit=10'),
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test' }) })
+    )
+  })
+
+  it('falls back to name when description annotation is absent', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ items: [{ metadata: { name: 'plain' }, spec: { type: 'Personal' } }] }))
+    const result = await callOrganizations() as { items: { displayName: string }[] }
+    expect(result.items[0].displayName).toBe('plain')
+  })
+
+  it('passes fieldSelector when search is provided', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
+    await callOrganizations({ search: 'acme' })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('fieldSelector=metadata.name%3Dacme'),
+      expect.anything()
+    )
+  })
+
+  it('returns empty list on non-ok response', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 403 }))
+    const result = await callOrganizations() as { items: unknown[] }
+    expect(result.items).toEqual([])
+  })
+
+  it('returns empty list when fetch throws', async () => {
+    fetchSpy.mockRejectedValue(new Error('network'))
+    const result = await callOrganizations() as { items: unknown[] }
+    expect(result.items).toEqual([])
+  })
+})
+
+describe('Query.organization', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetches a single org by name', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ metadata: { name: 'acme', annotations: {} }, spec: { type: 'Standard' } })
+    )
+    const result = await (additionalResolvers.Query!.organization as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { name: 'acme' }, ctx()) as { name: string }
+    expect(result.name).toBe('acme')
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/organizations/acme'),
+      expect.anything()
+    )
+  })
+
+  it('returns null on 404', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 404 }))
+    const result = await (additionalResolvers.Query!.organization as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { name: 'missing' }, ctx())
+    expect(result).toBeNull()
+  })
+})
+
+describe('Query.organizationProjects', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  const callOrgProjects = (args: { orgName: string; limit?: number; cursor?: string }) =>
+    (additionalResolvers.Query!.organizationProjects as (r: null, a: typeof args, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, args, ctx())
+
+  it('fetches projects via the org control plane URL', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            metadata: { name: 'proj-1', annotations: { 'kubernetes.io/description': 'Project One' } },
+            spec: { ownerRef: { name: 'acme', kind: 'Organization' } },
+          },
+        ],
+        metadata: {},
+      })
+    )
+    const result = await callOrgProjects({ orgName: 'acme' }) as { items: { name: string; displayName: string; organizationName: string }[] }
+    expect(result.items[0]).toMatchObject({ name: 'proj-1', displayName: 'Project One', organizationName: 'acme' })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/organizations/acme/control-plane/apis/resourcemanager.miloapis.com/v1alpha1/projects'),
+      expect.anything()
+    )
+  })
+
+  it('returns empty list on failure', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 403 }))
+    const result = await callOrgProjects({ orgName: 'acme' }) as { items: unknown[] }
+    expect(result.items).toEqual([])
+  })
+})
+
+describe('Query.organizationMembers', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  const callOrgMembers = (orgName: string) =>
+    (additionalResolvers.Query!.organizationMembers as (r: null, a: { orgName: string }, c: ReturnType<typeof ctx>) => Promise<unknown[]>)(null, { orgName }, ctx())
+
+  it('merges members and invitations in parallel', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('organizationmemberships')) {
+        return Promise.resolve(jsonResponse({
+          items: [{
+            metadata: { name: 'mbr-1', creationTimestamp: '2024-01-01T00:00:00Z' },
+            spec: { userRef: { name: 'user-1' }, roles: ['viewer'] },
+            status: { user: { givenName: 'Ada', familyName: 'Lovelace', email: 'ada@example.com' } },
+          }],
+        }))
+      }
+      return Promise.resolve(jsonResponse({
+        items: [{
+          metadata: { name: 'inv-1', creationTimestamp: '2024-02-01T00:00:00Z' },
+          spec: { givenName: 'Bob', familyName: 'Builder', email: 'bob@example.com', roles: ['editor'], state: 'Pending' },
+        }],
+      }))
+    })
+
+    const result = await callOrgMembers('acme')
+    expect(result).toHaveLength(2)
+    expect(result.find((m: unknown) => (m as { type: string }).type === 'member')).toMatchObject({
+      name: 'mbr-1', email: 'ada@example.com', givenName: 'Ada', roles: ['viewer'], type: 'member',
+    })
+    expect(result.find((m: unknown) => (m as { type: string }).type === 'invitation')).toMatchObject({
+      name: 'inv-1', email: 'bob@example.com', invitationState: 'Pending', type: 'invitation',
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns partial results when one fetch fails', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('organizationmemberships')) {
+        return Promise.resolve(new Response('{}', { status: 403 }))
+      }
+      return Promise.resolve(jsonResponse({ items: [{ metadata: { name: 'inv-1' }, spec: { email: 'x@y.com', roles: [] } }] }))
+    })
+    const result = await callOrgMembers('acme')
+    expect(result).toHaveLength(1)
+    expect((result[0] as { type: string }).type).toBe('invitation')
+  })
+
+  it('returns empty list when fetch throws', async () => {
+    fetchSpy.mockRejectedValue(new Error('network'))
+    expect(await callOrgMembers('acme')).toEqual([])
+  })
+})
+
+describe('Query.projects', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('lists all projects', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      items: [{ metadata: { name: 'proj-a', annotations: {} }, spec: { ownerRef: { name: 'acme' } } }],
+      metadata: {},
+    }))
+    const result = await (additionalResolvers.Query!.projects as (r: null, a: object, c: ReturnType<typeof ctx>) => Promise<{ items: { name: string }[] }>)(null, {}, ctx())
+    expect(result.items[0].name).toBe('proj-a')
+  })
+
+  it('returns empty list on non-ok response', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 500 }))
+    const result = await (additionalResolvers.Query!.projects as (r: null, a: object, c: ReturnType<typeof ctx>) => Promise<{ items: unknown[] }>)(null, {}, ctx())
+    expect(result.items).toEqual([])
+  })
+})
+
+describe('Query.project', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('fetches a single project by name', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse({
+      metadata: { name: 'proj-a', annotations: { 'kubernetes.io/description': 'Alpha' } },
+      spec: { ownerRef: { name: 'acme' } },
+    }))
+    const result = await (additionalResolvers.Query!.project as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<{ name: string; displayName: string } | null>)(null, { name: 'proj-a' }, ctx())
+    expect(result).toMatchObject({ name: 'proj-a', displayName: 'Alpha' })
+    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/projects/proj-a'), expect.anything())
+  })
+
+  it('returns null on 404', async () => {
+    fetchSpy.mockResolvedValue(new Response('{}', { status: 404 }))
+    const result = await (additionalResolvers.Query!.project as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { name: 'gone' }, ctx())
+    expect(result).toBeNull()
+  })
+})
+
 describe('Query.parseUserAgent and Query.geolocateIP', () => {
   it('parseUserAgent delegates to the user-agent service', () => {
     const result = additionalResolvers.Query!.parseUserAgent(null, {

--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -591,7 +591,7 @@ describe('Query.organizationMembers', () => {
         return Promise.resolve(jsonResponse({
           items: [{
             metadata: { name: 'mbr-1', creationTimestamp: '2024-01-01T00:00:00Z' },
-            spec: { userRef: { name: 'user-1' }, roles: ['viewer'] },
+            spec: { userRef: { name: 'user-1' }, roles: [{ name: 'viewer' }] },
             status: { user: { givenName: 'Ada', familyName: 'Lovelace', email: 'ada@example.com' } },
           }],
         }))
@@ -599,7 +599,7 @@ describe('Query.organizationMembers', () => {
       return Promise.resolve(jsonResponse({
         items: [{
           metadata: { name: 'inv-1', creationTimestamp: '2024-02-01T00:00:00Z' },
-          spec: { givenName: 'Bob', familyName: 'Builder', email: 'bob@example.com', roles: ['editor'], state: 'Pending' },
+          spec: { givenName: 'Bob', familyName: 'Builder', email: 'bob@example.com', roles: [{ name: 'editor' }], state: 'Pending' },
         }],
       }))
     })

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -103,13 +103,6 @@ interface UpstreamContactGroup {
 }
 
 interface UpstreamUser {
-  metadata?: { name?: string }
-  spec?: { email?: string; givenName?: string; familyName?: string }
-}
-
-// --- User resource interfaces ---
-
-interface UpstreamUser {
   metadata?: {
     name?: string
     uid?: string
@@ -306,6 +299,143 @@ async function fetchMemberships(
   }
   const body = (await response.json()) as UpstreamContactGroupMembershipList
   return { headers, memberships: body.items ?? [], continueToken: body.metadata?.continue ?? null }
+}
+
+// ============================================================================
+// Organizations + Projects
+// ============================================================================
+
+interface UpstreamOrganization {
+  metadata?: {
+    name?: string
+    creationTimestamp?: string
+    annotations?: Record<string, string>
+  }
+  spec?: { type?: string }
+  status?: { conditions?: Array<{ type?: string; status?: string }> }
+}
+
+interface UpstreamOrganizationList {
+  items?: UpstreamOrganization[]
+  metadata?: { continue?: string }
+}
+
+interface UpstreamProjectFull {
+  metadata?: {
+    name?: string
+    creationTimestamp?: string
+    annotations?: Record<string, string>
+  }
+  spec?: { ownerRef?: { name?: string; kind?: string } }
+  status?: { conditions?: Array<{ type?: string; status?: string }> }
+}
+
+interface UpstreamProjectList {
+  items?: UpstreamProjectFull[]
+  metadata?: { continue?: string }
+}
+
+interface UpstreamOrganizationMembership {
+  metadata?: { name?: string; creationTimestamp?: string }
+  spec?: { userRef?: { name?: string }; roles?: string[] }
+  status?: { user?: { givenName?: string; familyName?: string; email?: string } }
+}
+
+interface UpstreamOrganizationMembershipList {
+  items?: UpstreamOrganizationMembership[]
+}
+
+interface UpstreamUserInvitation {
+  metadata?: { name?: string; creationTimestamp?: string }
+  spec?: {
+    givenName?: string
+    familyName?: string
+    email?: string
+    roles?: string[]
+    state?: string
+  }
+}
+
+interface UpstreamUserInvitationList {
+  items?: UpstreamUserInvitation[]
+}
+
+function mapOrganization(raw: UpstreamOrganization) {
+  const annotations = raw.metadata?.annotations ?? {}
+  const displayName = annotations[PROJECT_DESCRIPTION_ANNOTATION] || raw.metadata?.name || ''
+  const readyCondition = raw.status?.conditions?.find((c) => c.type === 'Ready')
+  return {
+    name: raw.metadata?.name ?? '',
+    displayName,
+    type: raw.spec?.type ?? '',
+    createdAt: raw.metadata?.creationTimestamp ?? null,
+    state: readyCondition?.status ?? null,
+  }
+}
+
+function mapProjectFull(raw: UpstreamProjectFull) {
+  const annotations = raw.metadata?.annotations ?? {}
+  const displayName = annotations[PROJECT_DESCRIPTION_ANNOTATION] || raw.metadata?.name || ''
+  const readyCondition = raw.status?.conditions?.find((c) => c.type === 'Ready')
+  return {
+    name: raw.metadata?.name ?? '',
+    displayName,
+    organizationName: raw.spec?.ownerRef?.name ?? '',
+    createdAt: raw.metadata?.creationTimestamp ?? null,
+    state: readyCondition?.status ?? null,
+  }
+}
+
+function organizationsURL(params: { name?: string; limit?: number; cursor?: string; search?: string } = {}) {
+  const server = getK8sServer()
+  const base = `${server}/apis/resourcemanager.miloapis.com/v1alpha1/organizations`
+  if (params.name) return `${base}/${encodeURIComponent(params.name)}`
+  const query = new URLSearchParams()
+  if (params.limit) query.set('limit', String(params.limit))
+  if (params.cursor) query.set('continue', params.cursor)
+  if (params.search) query.set('fieldSelector', `metadata.name=${params.search}`)
+  const qs = query.toString()
+  return qs ? `${base}?${qs}` : base
+}
+
+function orgProjectsURL(orgName: string, params: { limit?: number; cursor?: string } = {}) {
+  const server = getK8sServer()
+  const base =
+    `${server}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/organizations/${encodeURIComponent(orgName)}/control-plane` +
+    `/apis/resourcemanager.miloapis.com/v1alpha1/projects`
+  const query = new URLSearchParams()
+  if (params.limit) query.set('limit', String(params.limit))
+  if (params.cursor) query.set('continue', params.cursor)
+  const qs = query.toString()
+  return qs ? `${base}?${qs}` : base
+}
+
+function orgMembershipsURL(orgName: string) {
+  const server = getK8sServer()
+  return (
+    `${server}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/namespaces/organization-${encodeURIComponent(orgName)}/organizationmemberships`
+  )
+}
+
+function orgInvitationsURL(orgName: string) {
+  const server = getK8sServer()
+  return (
+    `${server}/apis/iam.miloapis.com/v1alpha1` +
+    `/namespaces/organization-${encodeURIComponent(orgName)}/userinvitations`
+  )
+}
+
+function projectsListURL(params: { limit?: number; cursor?: string; search?: string } = {}) {
+  const server = getK8sServer()
+  const base = `${server}/apis/resourcemanager.miloapis.com/v1alpha1/projects`
+  const query = new URLSearchParams()
+  if (params.limit) query.set('limit', String(params.limit))
+  if (params.cursor) query.set('continue', params.cursor)
+  if (params.search) query.set('fieldSelector', `metadata.name=${params.search}`)
+  const qs = query.toString()
+  return qs ? `${base}?${qs}` : base
 }
 
 export const additionalResolvers = {
@@ -612,6 +742,181 @@ export const additionalResolvers = {
           error: error instanceof Error ? error.message : String(error),
         })
         return []
+      }
+    },
+
+    organizations: async (
+      _root: unknown,
+      args: { limit?: number; cursor?: string; search?: string },
+      context: ResolverContext
+    ) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const url = organizationsURL({ limit: args.limit, cursor: args.cursor, search: args.search })
+        const r = await getOriginalFetch()(url, {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo organizations fetch failed', { status: r.status, url })
+          return { items: [], continueToken: null }
+        }
+        const body = (await r.json()) as UpstreamOrganizationList
+        return {
+          items: (body.items ?? []).map(mapOrganization),
+          continueToken: body.metadata?.continue ?? null,
+        }
+      } catch (error) {
+        log.error('organizations resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return { items: [], continueToken: null }
+      }
+    },
+
+    organization: async (_root: unknown, args: { name: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const url = organizationsURL({ name: args.name })
+        const r = await getOriginalFetch()(url, {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo organization fetch failed', { name: args.name, status: r.status })
+          return null
+        }
+        return mapOrganization((await r.json()) as UpstreamOrganization)
+      } catch (error) {
+        log.error('organization resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return null
+      }
+    },
+
+    organizationProjects: async (
+      _root: unknown,
+      args: { orgName: string; limit?: number; cursor?: string },
+      context: ResolverContext
+    ) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const url = orgProjectsURL(args.orgName, { limit: args.limit, cursor: args.cursor })
+        const r = await getOriginalFetch()(url, {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo organizationProjects fetch failed', { orgName: args.orgName, status: r.status })
+          return { items: [], continueToken: null }
+        }
+        const body = (await r.json()) as UpstreamProjectList
+        return {
+          items: (body.items ?? []).map(mapProjectFull),
+          continueToken: body.metadata?.continue ?? null,
+        }
+      } catch (error) {
+        log.error('organizationProjects resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return { items: [], continueToken: null }
+      }
+    },
+
+    organizationMembers: async (
+      _root: unknown,
+      args: { orgName: string },
+      context: ResolverContext
+    ) => {
+      const authorization = getHeader(context, 'authorization')
+      const headers = { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' }
+      const fetchFn = getOriginalFetch()
+      try {
+        const [membershipsRes, invitationsRes] = await Promise.all([
+          fetchFn(orgMembershipsURL(args.orgName), { headers }),
+          fetchFn(orgInvitationsURL(args.orgName), { headers }),
+        ])
+
+        const result: {
+          name: string; givenName: string | null; familyName: string | null; email: string
+          roles: string[]; type: string; invitationState: string | null; createdAt: string | null
+        }[] = []
+
+        if (membershipsRes.ok) {
+          const body = (await membershipsRes.json()) as UpstreamOrganizationMembershipList
+          for (const m of body.items ?? []) {
+            result.push({
+              name: m.metadata?.name ?? '',
+              givenName: m.status?.user?.givenName ?? null,
+              familyName: m.status?.user?.familyName ?? null,
+              email: m.status?.user?.email ?? '',
+              roles: m.spec?.roles ?? [],
+              type: 'member',
+              invitationState: null,
+              createdAt: m.metadata?.creationTimestamp ?? null,
+            })
+          }
+        } else {
+          log.warn('milo orgMemberships fetch failed', { orgName: args.orgName, status: membershipsRes.status })
+        }
+
+        if (invitationsRes.ok) {
+          const body = (await invitationsRes.json()) as UpstreamUserInvitationList
+          for (const inv of body.items ?? []) {
+            result.push({
+              name: inv.metadata?.name ?? '',
+              givenName: inv.spec?.givenName ?? null,
+              familyName: inv.spec?.familyName ?? null,
+              email: inv.spec?.email ?? '',
+              roles: inv.spec?.roles ?? [],
+              type: 'invitation',
+              invitationState: inv.spec?.state ?? null,
+              createdAt: inv.metadata?.creationTimestamp ?? null,
+            })
+          }
+        } else {
+          log.warn('milo orgInvitations fetch failed', { orgName: args.orgName, status: invitationsRes.status })
+        }
+
+        return result
+      } catch (error) {
+        log.error('organizationMembers resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return []
+      }
+    },
+
+    projects: async (
+      _root: unknown,
+      args: { limit?: number; cursor?: string; search?: string },
+      context: ResolverContext
+    ) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const url = projectsListURL({ limit: args.limit, cursor: args.cursor, search: args.search })
+        const r = await getOriginalFetch()(url, {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo projects fetch failed', { status: r.status, url })
+          return { items: [], continueToken: null }
+        }
+        const body = (await r.json()) as UpstreamProjectList
+        return {
+          items: (body.items ?? []).map(mapProjectFull),
+          continueToken: body.metadata?.continue ?? null,
+        }
+      } catch (error) {
+        log.error('projects resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return { items: [], continueToken: null }
+      }
+    },
+
+    project: async (_root: unknown, args: { name: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const r = await getOriginalFetch()(projectURL(args.name), {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo project fetch failed', { name: args.name, status: r.status })
+          return null
+        }
+        return mapProjectFull((await r.json()) as UpstreamProjectFull)
+      } catch (error) {
+        log.error('project resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return null
       }
     },
   },

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -78,6 +78,7 @@ function sessionsURL(context: ResolverContext, options: { name?: string; userID?
 }
 
 const DESCRIPTION_ANNOTATION = 'kubernetes.io/description'
+const PROJECT_DESCRIPTION_ANNOTATION = 'kubernetes.io/description'
 
 interface UpstreamContactGroupMembership {
   metadata?: { name?: string }

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -107,6 +107,81 @@ interface UpstreamUser {
   spec?: { email?: string; givenName?: string; familyName?: string }
 }
 
+// --- User resource interfaces ---
+
+interface UpstreamUser {
+  metadata?: {
+    name?: string
+    uid?: string
+    resourceVersion?: string
+    creationTimestamp?: string
+    annotations?: Record<string, string>
+  }
+  spec?: { email?: string; givenName?: string; familyName?: string }
+  status?: {
+    registrationApproval?: string
+    state?: string
+    avatarUrl?: string
+    lastLoginProvider?: string
+  }
+}
+
+interface UpstreamUserIdentity {
+  metadata?: { name?: string; creationTimestamp?: string }
+  status?: { userUID?: string; providerID?: string; providerName?: string; username?: string }
+}
+
+interface UpstreamUserIdentityList {
+  items?: UpstreamUserIdentity[]
+}
+
+const NAME_REVIEW_ANNOTATION = 'iam.miloapis.com/name-review-required'
+
+function mapUser(raw: UpstreamUser) {
+  const annotations = raw.metadata?.annotations ?? {}
+  const newsletterRaw = annotations['preferences/newsletter']
+  return {
+    name: raw.metadata?.name ?? '',
+    uid: raw.metadata?.uid ?? null,
+    resourceVersion: raw.metadata?.resourceVersion ?? null,
+    email: raw.spec?.email ?? null,
+    givenName: raw.spec?.givenName ?? null,
+    familyName: raw.spec?.familyName ?? null,
+    createdAt: raw.metadata?.creationTimestamp ?? null,
+    theme: annotations['preferences/theme'] ?? null,
+    timezone: annotations['preferences/timezone'] ?? null,
+    newsletter: newsletterRaw != null ? newsletterRaw === 'true' : null,
+    onboardedAt: annotations['onboarding/completedAt'] ?? null,
+    registrationApproval: raw.status?.registrationApproval ?? null,
+    state: raw.status?.state ?? null,
+    avatarUrl: raw.status?.avatarUrl ?? null,
+    lastLoginProvider: raw.status?.lastLoginProvider ?? null,
+    nameReviewRequired: annotations[NAME_REVIEW_ANNOTATION] === 'true',
+  }
+}
+
+function mapUserIdentity(raw: UpstreamUserIdentity) {
+  return {
+    name: raw.metadata?.name ?? '',
+    createdAt: raw.metadata?.creationTimestamp ?? null,
+    userUID: raw.status?.userUID ?? null,
+    providerID: raw.status?.providerID ?? null,
+    providerName: raw.status?.providerName ?? null,
+    username: raw.status?.username ?? null,
+  }
+}
+
+function userURL(id: string) {
+  return `${getK8sServer()}/apis/iam.miloapis.com/v1alpha1/users/${encodeURIComponent(id)}`
+}
+
+function userIdentitiesURL(userID: string) {
+  return (
+    `${getK8sServer()}/apis/iam.miloapis.com/v1alpha1/users/${encodeURIComponent(userID)}` +
+    `/control-plane/apis/identity.miloapis.com/v1alpha1/useridentities`
+  )
+}
+
 interface UpstreamServiceConsumer {
   metadata?: { name?: string; creationTimestamp?: string }
   spec?: {
@@ -427,6 +502,58 @@ export const additionalResolvers = {
       }
     },
 
+    me: async (_root: unknown, _args: unknown, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const r = await getOriginalFetch()(userURL('me'), {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo user me fetch failed', { status: r.status })
+          return null
+        }
+        return mapUser((await r.json()) as UpstreamUser)
+      } catch (error) {
+        log.error('me resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return null
+      }
+    },
+
+    user: async (_root: unknown, args: { id: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const r = await getOriginalFetch()(userURL(args.id), {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo user fetch failed', { id: args.id, status: r.status })
+          return null
+        }
+        return mapUser((await r.json()) as UpstreamUser)
+      } catch (error) {
+        log.error('user resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return null
+      }
+    },
+
+    userIdentities: async (_root: unknown, args: { userID: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      try {
+        const r = await getOriginalFetch()(userIdentitiesURL(args.userID), {
+          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+        })
+        if (!r.ok) {
+          log.warn('milo userIdentities fetch failed', { userID: args.userID, status: r.status })
+          return []
+        }
+        const body = (await r.json()) as UpstreamUserIdentityList
+        return (body.items ?? []).map(mapUserIdentity)
+      } catch (error) {
+        log.error('userIdentities resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return []
+      }
+    },
+
     serviceConsumers: async (
       _root: unknown,
       args: { producerProject: string },
@@ -521,6 +648,99 @@ export const additionalResolvers = {
       throw new GraphQLError(`Failed to delete session: ${response.status}`, {
         extensions: { code: 'SESSION_DELETE_FAILED', status: response.status },
       })
+    },
+
+    updateUser: async (
+      _root: unknown,
+      args: { id: string; input: { givenName?: string; familyName?: string; email?: string } },
+      context: ResolverContext
+    ) => {
+      const authorization = getHeader(context, 'authorization')
+      const body = {
+        apiVersion: 'iam.miloapis.com/v1alpha1',
+        kind: 'User',
+        spec: {
+          ...(args.input.givenName != null ? { givenName: args.input.givenName } : {}),
+          ...(args.input.familyName != null ? { familyName: args.input.familyName } : {}),
+          ...(args.input.email != null ? { email: args.input.email } : {}),
+        },
+      }
+      const url = `${userURL(args.id)}?fieldManager=datum-cloud-portal`
+      const r = await getOriginalFetch()(url, {
+        method: 'PATCH',
+        headers: {
+          ...(authorization ? { Authorization: authorization } : {}),
+          'Content-Type': 'application/merge-patch+json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+      if (!r.ok) {
+        const detail = await r.text().catch(() => '')
+        log.warn('milo updateUser failed', { id: args.id, status: r.status, detail })
+        throw new GraphQLError(`Failed to update user: ${r.status}`, {
+          extensions: { code: 'USER_UPDATE_FAILED', status: r.status },
+        })
+      }
+      return mapUser((await r.json()) as UpstreamUser)
+    },
+
+    updateUserPreferences: async (
+      _root: unknown,
+      args: {
+        id: string
+        input: { theme?: string; timezone?: string; newsletter?: boolean; onboardedAt?: string }
+      },
+      context: ResolverContext
+    ) => {
+      const authorization = getHeader(context, 'authorization')
+      const annotations: Record<string, string> = {}
+      if (args.input.theme != null) annotations['preferences/theme'] = args.input.theme
+      if (args.input.timezone != null) annotations['preferences/timezone'] = args.input.timezone
+      if (args.input.newsletter != null) annotations['preferences/newsletter'] = String(args.input.newsletter)
+      if (args.input.onboardedAt != null) annotations['onboarding/completedAt'] = args.input.onboardedAt
+      const body = {
+        apiVersion: 'iam.miloapis.com/v1alpha1',
+        kind: 'User',
+        ...(Object.keys(annotations).length > 0 ? { metadata: { annotations } } : {}),
+      }
+      const url = `${userURL(args.id)}?fieldManager=datum-cloud-portal`
+      const r = await getOriginalFetch()(url, {
+        method: 'PATCH',
+        headers: {
+          ...(authorization ? { Authorization: authorization } : {}),
+          'Content-Type': 'application/merge-patch+json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+      if (!r.ok) {
+        const detail = await r.text().catch(() => '')
+        log.warn('milo updateUserPreferences failed', { id: args.id, status: r.status, detail })
+        throw new GraphQLError(`Failed to update user preferences: ${r.status}`, {
+          extensions: { code: 'USER_PREFERENCES_UPDATE_FAILED', status: r.status },
+        })
+      }
+      return mapUser((await r.json()) as UpstreamUser)
+    },
+
+    deleteUser: async (_root: unknown, args: { id: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      const r = await getOriginalFetch()(userURL(args.id), {
+        method: 'DELETE',
+        headers: {
+          ...(authorization ? { Authorization: authorization } : {}),
+          Accept: 'application/json',
+        },
+      })
+      if (!r.ok && r.status !== 404) {
+        const detail = await r.text().catch(() => '')
+        log.warn('milo deleteUser failed', { id: args.id, status: r.status, detail })
+        throw new GraphQLError(`Failed to delete user: ${r.status}`, {
+          extensions: { code: 'USER_DELETE_FAILED', status: r.status },
+        })
+      }
+      return r.ok ? mapUser((await r.json()) as UpstreamUser) : null
     },
   },
 }

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -337,7 +337,7 @@ interface UpstreamProjectList {
 
 interface UpstreamOrganizationMembership {
   metadata?: { name?: string; creationTimestamp?: string }
-  spec?: { userRef?: { name?: string }; roles?: string[] }
+  spec?: { userRef?: { name?: string }; roles?: Array<{ name: string; namespace?: string }> }
   status?: { user?: { givenName?: string; familyName?: string; email?: string } }
 }
 
@@ -351,7 +351,7 @@ interface UpstreamUserInvitation {
     givenName?: string
     familyName?: string
     email?: string
-    roles?: string[]
+    roles?: Array<{ name: string; namespace?: string }>
     state?: string
   }
 }
@@ -842,7 +842,7 @@ export const additionalResolvers = {
               givenName: m.status?.user?.givenName ?? null,
               familyName: m.status?.user?.familyName ?? null,
               email: m.status?.user?.email ?? '',
-              roles: m.spec?.roles ?? [],
+              roles: (m.spec?.roles ?? []).map((r) => r.name),
               type: 'member',
               invitationState: null,
               createdAt: m.metadata?.creationTimestamp ?? null,
@@ -860,7 +860,7 @@ export const additionalResolvers = {
               givenName: inv.spec?.givenName ?? null,
               familyName: inv.spec?.familyName ?? null,
               email: inv.spec?.email ?? '',
-              roles: inv.spec?.roles ?? [],
+              roles: (inv.spec?.roles ?? []).map((r) => r.name),
               type: 'invitation',
               invitationState: inv.spec?.state ?? null,
               createdAt: inv.metadata?.creationTimestamp ?? null,

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -361,6 +361,239 @@ interface UpstreamUserInvitationList {
   items?: UpstreamUserInvitation[]
 }
 
+// ─── Quota upstream types ─────────────────────────────────────────────────────
+
+interface UpstreamAllowanceBucket {
+  metadata?: { name?: string; namespace?: string }
+  spec?: {
+    resourceType?: string
+    consumerRef?: { apiGroup?: string; kind?: string; name?: string }
+  }
+  status?: { allocated?: number; limit?: number; available?: number }
+}
+
+interface UpstreamAllowanceBucketList {
+  items?: UpstreamAllowanceBucket[]
+}
+
+interface UpstreamResourceRegistration {
+  metadata?: {
+    name?: string
+    annotations?: Record<string, string>
+    labels?: Record<string, string>
+  }
+  spec?: { resourceType?: string; type?: string; description?: string }
+}
+
+interface UpstreamResourceRegistrationList {
+  items?: UpstreamResourceRegistration[]
+}
+
+interface UpstreamResourceGrant {
+  metadata?: {
+    name?: string
+    namespace?: string
+    creationTimestamp?: string
+    labels?: Record<string, string>
+  }
+  spec?: {
+    allowances?: Array<{
+      resourceType?: string
+      buckets?: Array<{ amount?: number }>
+    }>
+  }
+  status?: { conditions?: Array<{ type?: string; status?: string; message?: string }> }
+}
+
+interface UpstreamResourceGrantList {
+  items?: UpstreamResourceGrant[]
+}
+
+// ─── Service-catalog resolution (mirrors staff-portal service-catalog.ts) ────
+
+const QUOTA_SERVICE_DISPLAY_NAMES: Record<string, string> = {
+  'core.miloapis.com': 'Platform Core',
+  'notes.miloapis.com': 'Notes',
+  'dns.networking.miloapis.com': 'DNS',
+  'networking.datumapis.com': 'Networking',
+  'resourcemanager.miloapis.com': 'Organization & Projects',
+  'compute.datumapis.com': 'Compute',
+  'billing.miloapis.com': 'Billing',
+}
+
+const QUOTA_RESOURCE_DISPLAY_NAMES: Record<string, string> = {
+  'compute.datumapis.com/instances': 'Instances',
+  'compute.datumapis.com/vcpus': 'vCPUs',
+  'compute.datumapis.com/memory': 'Memory',
+  'compute.datumapis.com/workloads': 'Workloads',
+}
+
+const QUOTA_RESOURCE_TYPE_BRIDGE: Record<string, string> = {
+  'gateway.networking.k8s.io/gateways': 'networking.datumapis.com',
+  'gateway.networking.k8s.io/httproutes': 'networking.datumapis.com',
+  'gateway.networking.k8s.io/backendtlspolicies': 'networking.datumapis.com',
+  'gateway.envoyproxy.io/securitypolicies': 'networking.datumapis.com',
+  'gateway.envoyproxy.io/httproutefilters': 'networking.datumapis.com',
+  'gateway.envoyproxy.io/backends': 'networking.datumapis.com',
+  'gateway.envoyproxy.io/backendtrafficpolicies': 'networking.datumapis.com',
+  'discovery.k8s.io/endpointslices': 'networking.datumapis.com',
+  'networking.datumapis.com/httpproxies': 'networking.datumapis.com',
+  'networking.datumapis.com/domains': 'networking.datumapis.com',
+  'networking.datumapis.com/connectors': 'networking.datumapis.com',
+  'networking.datumapis.com/connectoradvertisements': 'networking.datumapis.com',
+  'networking.datumapis.com/trafficprotectionpolicies': 'networking.datumapis.com',
+  'dns.networking.miloapis.com/dnszones': 'dns.networking.miloapis.com',
+  'dns.networking.miloapis.com/dnsrecordsets': 'dns.networking.miloapis.com',
+}
+
+function quotaServiceDisplayName(owner: string | undefined, resourceType: string): string {
+  const serviceName = owner ?? QUOTA_RESOURCE_TYPE_BRIDGE[resourceType]
+  if (!serviceName) return 'Other'
+  return QUOTA_SERVICE_DISPLAY_NAMES[serviceName] ?? 'Other'
+}
+
+function quotaResourceDisplayName(serverDisplayName: string | undefined, resourceType: string): string {
+  return serverDisplayName ?? QUOTA_RESOURCE_DISPLAY_NAMES[resourceType] ?? resourceType
+}
+
+function buildRegistrationMap(
+  list: UpstreamResourceRegistrationList
+): Map<string, UpstreamResourceRegistration> {
+  const map = new Map<string, UpstreamResourceRegistration>()
+  for (const reg of list.items ?? []) {
+    if (reg.spec?.resourceType) map.set(reg.spec.resourceType, reg)
+  }
+  return map
+}
+
+// ─── Quota URL helpers ────────────────────────────────────────────────────────
+
+function resourceRegistrationsURL() {
+  return `${getK8sServer()}/apis/quota.miloapis.com/v1alpha1/resourceregistrations`
+}
+
+function orgQuotaBucketsURL(orgName: string) {
+  const base =
+    `${getK8sServer()}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/organizations/${encodeURIComponent(orgName)}/control-plane` +
+    `/apis/quota.miloapis.com/v1alpha1` +
+    `/namespaces/organization-${encodeURIComponent(orgName)}/allowancebuckets`
+  const qs = new URLSearchParams({
+    fieldSelector: `spec.consumerRef.kind=Organization,spec.consumerRef.name=${orgName}`,
+  })
+  return `${base}?${qs}`
+}
+
+function projectQuotaBucketsURL(projectName: string) {
+  const base =
+    `${getK8sServer()}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/projects/${encodeURIComponent(projectName)}/control-plane` +
+    `/apis/quota.miloapis.com/v1alpha1/namespaces/milo-system/allowancebuckets`
+  const qs = new URLSearchParams({
+    fieldSelector: `spec.consumerRef.kind=Project,spec.consumerRef.name=${projectName}`,
+  })
+  return `${base}?${qs}`
+}
+
+function orgQuotaGrantsURL(orgName: string) {
+  const base =
+    `${getK8sServer()}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/organizations/${encodeURIComponent(orgName)}/control-plane` +
+    `/apis/quota.miloapis.com/v1alpha1` +
+    `/namespaces/organization-${encodeURIComponent(orgName)}/resourcegrants`
+  const qs = new URLSearchParams({
+    fieldSelector: `spec.consumerRef.kind=Organization,spec.consumerRef.name=${orgName}`,
+  })
+  return `${base}?${qs}`
+}
+
+function projectQuotaGrantsURL(projectName: string) {
+  const base =
+    `${getK8sServer()}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/projects/${encodeURIComponent(projectName)}/control-plane` +
+    `/apis/quota.miloapis.com/v1alpha1/namespaces/milo-system/resourcegrants`
+  const qs = new URLSearchParams({
+    fieldSelector: `spec.consumerRef.kind=Project,spec.consumerRef.name=${projectName}`,
+  })
+  return `${base}?${qs}`
+}
+
+function mapQuotaBuckets(
+  bucketList: UpstreamAllowanceBucketList,
+  regs: Map<string, UpstreamResourceRegistration>
+) {
+  return (bucketList.items ?? [])
+    .filter((b) => {
+      const reg = regs.get(b.spec?.resourceType ?? '')
+      return String(reg?.spec?.type ?? '') !== 'Feature'
+    })
+    .map((b) => {
+      const resourceType = b.spec?.resourceType ?? ''
+      const reg = regs.get(resourceType)
+      const annotations = reg?.metadata?.annotations ?? {}
+      const labels = reg?.metadata?.labels ?? {}
+      const owner = labels['services.miloapis.com/owner'] ?? labels['services.miloapis.com/service']
+      return {
+        name: b.metadata?.name ?? '',
+        namespace: b.metadata?.namespace ?? '',
+        resourceType,
+        consumerKind: b.spec?.consumerRef?.kind ?? '',
+        consumerName: b.spec?.consumerRef?.name ?? '',
+        consumerApiGroup: b.spec?.consumerRef?.apiGroup ?? '',
+        allocated: b.status?.allocated ?? 0,
+        limit: b.status?.limit ?? 0,
+        available: b.status?.available ?? 0,
+        displayName: quotaResourceDisplayName(annotations['kubernetes.io/display-name'], resourceType),
+        description: annotations['kubernetes.io/description'] ?? reg?.spec?.description ?? null,
+        registrationType: reg?.spec?.type ?? null,
+        serviceOwner: owner ?? null,
+        serviceDisplayName: quotaServiceDisplayName(owner, resourceType),
+      }
+    })
+}
+
+function mapQuotaGrants(
+  grantList: UpstreamResourceGrantList,
+  regs: Map<string, UpstreamResourceRegistration>
+) {
+  return (grantList.items ?? []).map((g) => {
+    const allowanceMap = new Map<string, number>()
+    for (const allowance of g.spec?.allowances ?? []) {
+      const rt = allowance.resourceType ?? ''
+      const sum = (allowance.buckets ?? []).reduce((acc, b) => acc + (b?.amount ?? 0), 0)
+      allowanceMap.set(rt, (allowanceMap.get(rt) ?? 0) + sum)
+    }
+
+    const allowances = Array.from(allowanceMap.entries()).map(([resourceType, amount]) => {
+      const reg = regs.get(resourceType)
+      const annotations = reg?.metadata?.annotations ?? {}
+      const labels = reg?.metadata?.labels ?? {}
+      const owner = labels['services.miloapis.com/owner'] ?? labels['services.miloapis.com/service']
+      return {
+        resourceType,
+        displayName: quotaResourceDisplayName(annotations['kubernetes.io/display-name'], resourceType),
+        serviceDisplayName: quotaServiceDisplayName(owner, resourceType),
+        amount,
+      }
+    })
+
+    return {
+      name: g.metadata?.name ?? '',
+      namespace: g.metadata?.namespace ?? '',
+      createdAt: g.metadata?.creationTimestamp ?? null,
+      autoCreated: g.metadata?.labels?.['quota.miloapis.com/auto-created'] === 'true',
+      allowances,
+      conditions: (g.status?.conditions ?? []).map((c) => ({
+        type: c.type ?? '',
+        status: c.status ?? '',
+        message: c.message ?? null,
+      })),
+    }
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 function mapOrganization(raw: UpstreamOrganization) {
   const annotations = raw.metadata?.annotations ?? {}
   const displayName = annotations[PROJECT_DESCRIPTION_ANNOTATION] || raw.metadata?.name || ''
@@ -918,6 +1151,86 @@ export const additionalResolvers = {
       } catch (error) {
         log.error('project resolver failed', { error: error instanceof Error ? error.message : String(error) })
         return null
+      }
+    },
+
+    orgQuotaBuckets: async (_root: unknown, args: { orgName: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      const headers = { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' }
+      const fetchFn = getOriginalFetch()
+      try {
+        const [bucketsRes, regsRes] = await Promise.all([
+          fetchFn(orgQuotaBucketsURL(args.orgName), { headers }),
+          fetchFn(resourceRegistrationsURL(), { headers }),
+        ])
+        const buckets: UpstreamAllowanceBucketList = bucketsRes.ok ? (await bucketsRes.json()) as UpstreamAllowanceBucketList : { items: [] }
+        const regsBody: UpstreamResourceRegistrationList = regsRes.ok ? (await regsRes.json()) as UpstreamResourceRegistrationList : { items: [] }
+        if (!bucketsRes.ok) log.warn('milo orgQuotaBuckets fetch failed', { orgName: args.orgName, status: bucketsRes.status })
+        if (!regsRes.ok) log.warn('milo resourceRegistrations fetch failed', { status: regsRes.status })
+        return { items: mapQuotaBuckets(buckets, buildRegistrationMap(regsBody)) }
+      } catch (error) {
+        log.error('orgQuotaBuckets resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return { items: [] }
+      }
+    },
+
+    projectQuotaBuckets: async (_root: unknown, args: { projectName: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      const headers = { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' }
+      const fetchFn = getOriginalFetch()
+      try {
+        const [bucketsRes, regsRes] = await Promise.all([
+          fetchFn(projectQuotaBucketsURL(args.projectName), { headers }),
+          fetchFn(resourceRegistrationsURL(), { headers }),
+        ])
+        const buckets: UpstreamAllowanceBucketList = bucketsRes.ok ? (await bucketsRes.json()) as UpstreamAllowanceBucketList : { items: [] }
+        const regsBody: UpstreamResourceRegistrationList = regsRes.ok ? (await regsRes.json()) as UpstreamResourceRegistrationList : { items: [] }
+        if (!bucketsRes.ok) log.warn('milo projectQuotaBuckets fetch failed', { projectName: args.projectName, status: bucketsRes.status })
+        if (!regsRes.ok) log.warn('milo resourceRegistrations fetch failed', { status: regsRes.status })
+        return { items: mapQuotaBuckets(buckets, buildRegistrationMap(regsBody)) }
+      } catch (error) {
+        log.error('projectQuotaBuckets resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return { items: [] }
+      }
+    },
+
+    orgQuotaGrants: async (_root: unknown, args: { orgName: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      const headers = { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' }
+      const fetchFn = getOriginalFetch()
+      try {
+        const [grantsRes, regsRes] = await Promise.all([
+          fetchFn(orgQuotaGrantsURL(args.orgName), { headers }),
+          fetchFn(resourceRegistrationsURL(), { headers }),
+        ])
+        const grants: UpstreamResourceGrantList = grantsRes.ok ? (await grantsRes.json()) as UpstreamResourceGrantList : { items: [] }
+        const regsBody: UpstreamResourceRegistrationList = regsRes.ok ? (await regsRes.json()) as UpstreamResourceRegistrationList : { items: [] }
+        if (!grantsRes.ok) log.warn('milo orgQuotaGrants fetch failed', { orgName: args.orgName, status: grantsRes.status })
+        if (!regsRes.ok) log.warn('milo resourceRegistrations fetch failed', { status: regsRes.status })
+        return { items: mapQuotaGrants(grants, buildRegistrationMap(regsBody)) }
+      } catch (error) {
+        log.error('orgQuotaGrants resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return { items: [] }
+      }
+    },
+
+    projectQuotaGrants: async (_root: unknown, args: { projectName: string }, context: ResolverContext) => {
+      const authorization = getHeader(context, 'authorization')
+      const headers = { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' }
+      const fetchFn = getOriginalFetch()
+      try {
+        const [grantsRes, regsRes] = await Promise.all([
+          fetchFn(projectQuotaGrantsURL(args.projectName), { headers }),
+          fetchFn(resourceRegistrationsURL(), { headers }),
+        ])
+        const grants: UpstreamResourceGrantList = grantsRes.ok ? (await grantsRes.json()) as UpstreamResourceGrantList : { items: [] }
+        const regsBody: UpstreamResourceRegistrationList = regsRes.ok ? (await regsRes.json()) as UpstreamResourceRegistrationList : { items: [] }
+        if (!grantsRes.ok) log.warn('milo projectQuotaGrants fetch failed', { projectName: args.projectName, status: grantsRes.status })
+        if (!regsRes.ok) log.warn('milo resourceRegistrations fetch failed', { status: regsRes.status })
+        return { items: mapQuotaGrants(grants, buildRegistrationMap(regsBody)) }
+      } catch (error) {
+        log.error('projectQuotaGrants resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        return { items: [] }
       }
     },
   },

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -153,6 +153,56 @@ export const additionalTypeDefs = /* GraphQL */ `
     onboardedAt: String
   }
 
+  type Organization {
+    "metadata.name — the stable organization ID."
+    name: String!
+    "Human-readable name from the kubernetes.io/description annotation, falling back to name."
+    displayName: String!
+    "Organization type: Personal or Standard."
+    type: String!
+    createdAt: String
+    "Status of the Ready condition."
+    state: String
+  }
+
+  type OrganizationList {
+    items: [Organization!]!
+    "Pagination cursor — pass as cursor on the next call to continue listing."
+    continueToken: String
+  }
+
+  type Project {
+    "metadata.name — the stable project ID."
+    name: String!
+    "Human-readable name from the kubernetes.io/description annotation, falling back to name."
+    displayName: String!
+    "Name of the owning organization."
+    organizationName: String!
+    createdAt: String
+    "Status of the Ready condition."
+    state: String
+  }
+
+  type ProjectList {
+    items: [Project!]!
+    "Pagination cursor — pass as cursor on the next call to continue listing."
+    continueToken: String
+  }
+
+  type OrgMember {
+    "Resource name of the membership or invitation."
+    name: String!
+    givenName: String
+    familyName: String
+    email: String!
+    roles: [String!]!
+    "member or invitation"
+    type: String!
+    "Only set for invitations: Pending, Accepted, Declined."
+    invitationState: String
+    createdAt: String
+  }
+
   extend type Query {
     parseUserAgent(userAgent: String!): ParsedUserAgent!
     geolocateIP(ip: String!): GeoLocation
@@ -199,6 +249,18 @@ export const additionalTypeDefs = /* GraphQL */ `
     user(id: String!): User
     "Lists UserIdentity resources scoped to the given user."
     userIdentities(userID: String!): [UserIdentity!]!
+    "Lists all organizations the caller can access."
+    organizations(limit: Int, cursor: String, search: String): OrganizationList!
+    "Returns a single organization by name."
+    organization(name: String!): Organization
+    "Lists projects in an organization via its control plane."
+    organizationProjects(orgName: String!, limit: Int, cursor: String): ProjectList!
+    "Lists members and pending invitations for an organization."
+    organizationMembers(orgName: String!): [OrgMember!]!
+    "Lists all projects the caller can access."
+    projects(limit: Int, cursor: String, search: String): ProjectList!
+    "Returns a single project by name."
+    project(name: String!): Project
   }
 
   extend type Mutation {

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -203,6 +203,77 @@ export const additionalTypeDefs = /* GraphQL */ `
     createdAt: String
   }
 
+  type QuotaBucket {
+    "metadata.name"
+    name: String!
+    "metadata.namespace (needed for grant creation)"
+    namespace: String!
+    "spec.resourceType"
+    resourceType: String!
+    "spec.consumerRef.kind — Organization or Project"
+    consumerKind: String!
+    "spec.consumerRef.name"
+    consumerName: String!
+    "spec.consumerRef.apiGroup"
+    consumerApiGroup: String!
+    "status.allocated"
+    allocated: Int!
+    "status.limit"
+    limit: Int!
+    "status.available"
+    available: Int!
+    "Display name: kubernetes.io/display-name annotation → hardcoded map → raw resourceType"
+    displayName: String!
+    "kubernetes.io/description annotation or spec.description from the ResourceRegistration"
+    description: String
+    "spec.type from the ResourceRegistration: Entity, Allocation, or Feature"
+    registrationType: String
+    "Owning service canonical name from labels (services.miloapis.com/owner or /service)"
+    serviceOwner: String
+    "Resolved human-readable service group name"
+    serviceDisplayName: String!
+  }
+
+  type QuotaBucketList {
+    items: [QuotaBucket!]!
+  }
+
+  type QuotaGrantAllowance {
+    "resourceType for this allowance"
+    resourceType: String!
+    "Resolved display name (same logic as QuotaBucket.displayName)"
+    displayName: String!
+    "Resolved service group name"
+    serviceDisplayName: String!
+    "Sum of all bucket amounts for this resourceType within the grant"
+    amount: Int!
+  }
+
+  type QuotaCondition {
+    type: String!
+    status: String!
+    message: String
+  }
+
+  type QuotaGrant {
+    "metadata.name"
+    name: String!
+    "metadata.namespace"
+    namespace: String!
+    "metadata.creationTimestamp"
+    createdAt: String
+    "Whether this grant was auto-created (quota.miloapis.com/auto-created label)"
+    autoCreated: Boolean!
+    "Flattened and enriched allowances (one entry per resourceType)"
+    allowances: [QuotaGrantAllowance!]!
+    "status.conditions for status badge display"
+    conditions: [QuotaCondition!]!
+  }
+
+  type QuotaGrantList {
+    items: [QuotaGrant!]!
+  }
+
   extend type Query {
     parseUserAgent(userAgent: String!): ParsedUserAgent!
     geolocateIP(ip: String!): GeoLocation
@@ -261,6 +332,14 @@ export const additionalTypeDefs = /* GraphQL */ `
     projects(limit: Int, cursor: String, search: String): ProjectList!
     "Returns a single project by name."
     project(name: String!): Project
+    "Enriched quota buckets for an org — joins AllowanceBuckets with ResourceRegistrations server-side."
+    orgQuotaBuckets(orgName: String!): QuotaBucketList!
+    "Enriched quota buckets for a project — joins AllowanceBuckets with ResourceRegistrations server-side."
+    projectQuotaBuckets(projectName: String!): QuotaBucketList!
+    "Enriched resource grants for an org with flattened, display-enriched allowances."
+    orgQuotaGrants(orgName: String!): QuotaGrantList!
+    "Enriched resource grants for a project with flattened, display-enriched allowances."
+    projectQuotaGrants(projectName: String!): QuotaGrantList!
   }
 
   extend type Mutation {

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -107,6 +107,52 @@ export const additionalTypeDefs = /* GraphQL */ `
     familyName: String
   }
 
+  type User {
+    "metadata.name — the stable user ID."
+    name: String!
+    uid: String
+    resourceVersion: String
+    email: String
+    givenName: String
+    familyName: String
+    createdAt: String
+    "preferences/theme annotation."
+    theme: String
+    "preferences/timezone annotation."
+    timezone: String
+    "preferences/newsletter annotation parsed to boolean."
+    newsletter: Boolean
+    "onboarding/completedAt annotation."
+    onboardedAt: String
+    registrationApproval: String
+    state: String
+    avatarUrl: String
+    lastLoginProvider: String
+    nameReviewRequired: Boolean
+  }
+
+  type UserIdentity {
+    name: String!
+    createdAt: String
+    userUID: String
+    providerID: String
+    providerName: String
+    username: String
+  }
+
+  input UpdateUserInput {
+    givenName: String
+    familyName: String
+    email: String
+  }
+
+  input UpdateUserPreferencesInput {
+    theme: String
+    timezone: String
+    newsletter: Boolean
+    onboardedAt: String
+  }
+
   extend type Query {
     parseUserAgent(userAgent: String!): ParsedUserAgent!
     geolocateIP(ip: String!): GeoLocation
@@ -148,9 +194,20 @@ export const additionalTypeDefs = /* GraphQL */ `
     lookup failures return null for that entry (filtered from the result).
     """
     userSummaries(names: [String!]!): [UserSummary!]!
+    "Returns the full User resource for the authenticated caller (id='me') or by explicit ID."
+    me: User
+    user(id: String!): User
+    "Lists UserIdentity resources scoped to the given user."
+    userIdentities(userID: String!): [UserIdentity!]!
   }
 
   extend type Mutation {
     deleteSession(id: String!): Boolean!
+    "Updates a user's profile fields (givenName, familyName, email)."
+    updateUser(id: String!, input: UpdateUserInput!): User!
+    "Updates a user's preferences stored as annotations."
+    updateUserPreferences(id: String!, input: UpdateUserPreferencesInput!): User!
+    "Deletes a user account. Returns the deleted user."
+    deleteUser(id: String!): User
   }
 `


### PR DESCRIPTION
## Summary

- Adds `organizations`, `organization`, `organizationProjects`, `organizationMembers` query resolvers — eliminates per-page REST calls for org/member data
- Adds `projects`, `project` resolvers for cross-org project listing
- Adds `orgQuotaBuckets`, `projectQuotaBuckets`, `orgQuotaGrants`, `projectQuotaGrants` resolvers — joins AllowanceBuckets with ResourceRegistrations server-side, resolves service/resource display names, filters Feature-type registrations, flattens grant allowances
- Fixes role extraction from org membership objects (`spec.roles` is `{name, namespace}[]` not `string[]`)
- All resolvers use caller bearer token via `getOriginalFetch()`; partial fetch failures degrade gracefully

## Test plan

- [ ] 65 resolver tests pass (`npm test`)
- [ ] Org list, org detail, org members load in staff-portal
- [ ] Project list, project detail load
- [ ] Org/project quota Usage and Grants tabs load with correct display names and groupings
- [ ] Edit quota dialog opens with correct resource type and limit
- [ ] Delete grant works; auto-created grants have delete disabled