### PR TITLE
fix: expose userRef.name on organizationMembers as userName

### DIFF
--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -608,9 +608,11 @@ describe('Query.organizationMembers', () => {
     expect(result).toHaveLength(2)
     expect(result.find((m: unknown) => (m as { type: string }).type === 'member')).toMatchObject({
       name: 'mbr-1', email: 'ada@example.com', givenName: 'Ada', roles: ['viewer'], type: 'member',
+      userName: 'user-1',
     })
     expect(result.find((m: unknown) => (m as { type: string }).type === 'invitation')).toMatchObject({
       name: 'inv-1', email: 'bob@example.com', invitationState: 'Pending', type: 'invitation',
+      userName: null,
     })
     expect(fetchSpy).toHaveBeenCalledTimes(2)
   })

--- a/src/gateway/graphql/resolvers.ts
+++ b/src/gateway/graphql/resolvers.ts
@@ -1066,6 +1066,7 @@ export const additionalResolvers = {
         const result: {
           name: string; givenName: string | null; familyName: string | null; email: string
           roles: string[]; type: string; invitationState: string | null; createdAt: string | null
+          userName: string | null
         }[] = []
 
         if (membershipsRes.ok) {
@@ -1080,6 +1081,7 @@ export const additionalResolvers = {
               type: 'member',
               invitationState: null,
               createdAt: m.metadata?.creationTimestamp ?? null,
+              userName: m.spec?.userRef?.name ?? null,
             })
           }
         } else {
@@ -1098,6 +1100,7 @@ export const additionalResolvers = {
               type: 'invitation',
               invitationState: inv.spec?.state ?? null,
               createdAt: inv.metadata?.creationTimestamp ?? null,
+              userName: null,
             })
           }
         } else {

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -201,6 +201,8 @@ export const additionalTypeDefs = /* GraphQL */ `
     "Only set for invitations: Pending, Accepted, Declined."
     invitationState: String
     createdAt: String
+    "The member's user resource name. Null for invitations, which have no user yet."
+    userName: String
   }
 
   type QuotaBucket {


### PR DESCRIPTION
## Summary
- `organizationMembers` only exposed the membership/invitation resource's own `metadata.name`, not the actual user ID — frontend links built from it 404 (datum-cloud/staff-portal#572).
- Adds `userName` to the `OrgMember` GraphQL type, populated from `spec.userRef.name` on the upstream `OrganizationMembership`. Null for invitation rows, which have no user yet.

## Test plan
- [x] `resolvers.test.ts` asserts `userName` is populated for members and null for invitations
- [x] `npx tsc --noEmit` passes