### PR TITLE
feat: Nest members and onboarding fields on Organization

### DIFF
--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -448,7 +448,13 @@ describe('Query.organizations', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   const callOrganizations = (args: { limit?: number; cursor?: string; search?: string } = {}) =>
-    (additionalResolvers.Query!.organizations as (r: null, a: typeof args, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, args, ctx())
+    (
+      additionalResolvers.Query!.organizations as (
+        r: null,
+        a: typeof args,
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, args, ctx())
 
   it('lists organizations and maps displayName from annotation', async () => {
     fetchSpy.mockResolvedValue(
@@ -460,28 +466,99 @@ describe('Query.organizations', () => {
               creationTimestamp: '2024-01-01T00:00:00Z',
               annotations: { 'kubernetes.io/display-name': 'Acme Corp' },
             },
-            spec: { type: 'Standard' },
-            status: { conditions: [{ type: 'Ready', status: 'True' }] },
+            spec: {
+              type: 'Standard',
+              contactInfo: { businessName: 'Acme LLC', name: 'Ada', email: 'ada@acme.test' },
+            },
+            status: {
+              conditions: [
+                { type: 'Ready', status: 'True' },
+                {
+                  type: 'OnboardingComplete',
+                  status: 'True',
+                  reason: 'Complete',
+                  message: 'Organization is fully onboarded',
+                },
+              ],
+            },
           },
         ],
         metadata: { continue: 'tok123' },
       })
     )
 
-    const result = await callOrganizations({ limit: 10 }) as { items: unknown[]; continueToken: string }
+    const result = (await callOrganizations({ limit: 10 })) as {
+      items: unknown[]
+      continueToken: string
+    }
     expect(result.items).toHaveLength(1)
-    expect(result.items[0]).toMatchObject({ name: 'acme', displayName: 'Acme Corp', type: 'Standard', state: 'True' })
+    expect(result.items[0]).toMatchObject({
+      name: 'acme',
+      displayName: 'Acme Corp',
+      type: 'Standard',
+      state: 'True',
+      onboardingComplete: true,
+      onboardingReason: 'Complete',
+      onboardingMessage: 'Organization is fully onboarded',
+      contactInfo: { businessName: 'Acme LLC', name: 'Ada', email: 'ada@acme.test' },
+    })
     expect(result.continueToken).toBe('tok123')
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining('/apis/resourcemanager.miloapis.com/v1alpha1/organizations?limit=10'),
-      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test' }) })
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test' }),
+      })
     )
   })
 
   it('falls back to name when description annotation is absent', async () => {
-    fetchSpy.mockResolvedValue(jsonResponse({ items: [{ metadata: { name: 'plain' }, spec: { type: 'Personal' } }] }))
-    const result = await callOrganizations() as { items: { displayName: string }[] }
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ items: [{ metadata: { name: 'plain' }, spec: { type: 'Personal' } }] })
+    )
+    const result = (await callOrganizations()) as {
+      items: { displayName: string; onboardingComplete: boolean }[]
+    }
     expect(result.items[0].displayName).toBe('plain')
+    expect(result.items[0].onboardingComplete).toBe(false)
+  })
+
+  it('maps onboardingComplete false when OnboardingComplete is not True', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            metadata: { name: 'pending-org' },
+            spec: { type: 'Standard' },
+            status: {
+              conditions: [
+                {
+                  type: 'OnboardingComplete',
+                  status: 'False',
+                  reason: 'PaymentMethodMissing',
+                  message:
+                    'Organization billing account does not have a ready default payment method',
+                },
+              ],
+            },
+          },
+        ],
+      })
+    )
+    const result = (await callOrganizations()) as {
+      items: {
+        onboardingComplete: boolean
+        onboardingReason: string | null
+        onboardingMessage: string | null
+        contactInfo: null
+      }[]
+    }
+    expect(result.items[0]).toMatchObject({
+      onboardingComplete: false,
+      onboardingReason: 'PaymentMethodMissing',
+      onboardingMessage:
+        'Organization billing account does not have a ready default payment method',
+      contactInfo: null,
+    })
   })
 
   it('passes fieldSelector when search is provided', async () => {
@@ -495,13 +572,13 @@ describe('Query.organizations', () => {
 
   it('returns empty list on non-ok response', async () => {
     fetchSpy.mockResolvedValue(new Response('{}', { status: 403 }))
-    const result = await callOrganizations() as { items: unknown[] }
+    const result = (await callOrganizations()) as { items: unknown[] }
     expect(result.items).toEqual([])
   })
 
   it('returns empty list when fetch throws', async () => {
     fetchSpy.mockRejectedValue(new Error('network'))
-    const result = await callOrganizations() as { items: unknown[] }
+    const result = (await callOrganizations()) as { items: unknown[] }
     expect(result.items).toEqual([])
   })
 })
@@ -519,7 +596,13 @@ describe('Query.organization', () => {
     fetchSpy.mockResolvedValue(
       jsonResponse({ metadata: { name: 'acme', annotations: {} }, spec: { type: 'Standard' } })
     )
-    const result = await (additionalResolvers.Query!.organization as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { name: 'acme' }, ctx()) as { name: string }
+    const result = (await (
+      additionalResolvers.Query!.organization as (
+        r: null,
+        a: { name: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, { name: 'acme' }, ctx())) as { name: string }
     expect(result.name).toBe('acme')
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining('/organizations/acme'),
@@ -529,7 +612,13 @@ describe('Query.organization', () => {
 
   it('returns null on 404', async () => {
     fetchSpy.mockResolvedValue(new Response('{}', { status: 404 }))
-    const result = await (additionalResolvers.Query!.organization as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { name: 'missing' }, ctx())
+    const result = await (
+      additionalResolvers.Query!.organization as (
+        r: null,
+        a: { name: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, { name: 'missing' }, ctx())
     expect(result).toBeNull()
   })
 })
@@ -544,31 +633,48 @@ describe('Query.organizationProjects', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   const callOrgProjects = (args: { orgName: string; limit?: number; cursor?: string }) =>
-    (additionalResolvers.Query!.organizationProjects as (r: null, a: typeof args, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, args, ctx())
+    (
+      additionalResolvers.Query!.organizationProjects as (
+        r: null,
+        a: typeof args,
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, args, ctx())
 
   it('fetches projects via the org control plane URL', async () => {
     fetchSpy.mockResolvedValue(
       jsonResponse({
         items: [
           {
-            metadata: { name: 'proj-1', annotations: { 'kubernetes.io/description': 'Project One' } },
+            metadata: {
+              name: 'proj-1',
+              annotations: { 'kubernetes.io/description': 'Project One' },
+            },
             spec: { ownerRef: { name: 'acme', kind: 'Organization' } },
           },
         ],
         metadata: {},
       })
     )
-    const result = await callOrgProjects({ orgName: 'acme' }) as { items: { name: string; displayName: string; organizationName: string }[] }
-    expect(result.items[0]).toMatchObject({ name: 'proj-1', displayName: 'Project One', organizationName: 'acme' })
+    const result = (await callOrgProjects({ orgName: 'acme' })) as {
+      items: { name: string; displayName: string; organizationName: string }[]
+    }
+    expect(result.items[0]).toMatchObject({
+      name: 'proj-1',
+      displayName: 'Project One',
+      organizationName: 'acme',
+    })
     expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/organizations/acme/control-plane/apis/resourcemanager.miloapis.com/v1alpha1/projects'),
+      expect.stringContaining(
+        '/organizations/acme/control-plane/apis/resourcemanager.miloapis.com/v1alpha1/projects'
+      ),
       expect.anything()
     )
   })
 
   it('returns empty list on failure', async () => {
     fetchSpy.mockResolvedValue(new Response('{}', { status: 403 }))
-    const result = await callOrgProjects({ orgName: 'acme' }) as { items: unknown[] }
+    const result = (await callOrgProjects({ orgName: 'acme' })) as { items: unknown[] }
     expect(result.items).toEqual([])
   })
 })
@@ -583,36 +689,74 @@ describe('Query.organizationMembers', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   const callOrgMembers = (orgName: string) =>
-    (additionalResolvers.Query!.organizationMembers as (r: null, a: { orgName: string }, c: ReturnType<typeof ctx>) => Promise<unknown[]>)(null, { orgName }, ctx())
+    (
+      additionalResolvers.Query!.organizationMembers as (
+        r: null,
+        a: { orgName: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown[]>
+    )(null, { orgName }, ctx())
 
   it('merges members and invitations in parallel', async () => {
     fetchSpy.mockImplementation((url: string) => {
       if (url.includes('organizationmemberships')) {
-        return Promise.resolve(jsonResponse({
-          items: [{
-            metadata: { name: 'mbr-1', creationTimestamp: '2024-01-01T00:00:00Z' },
-            spec: { userRef: { name: 'user-1' }, roles: [{ name: 'viewer' }] },
-            status: { user: { givenName: 'Ada', familyName: 'Lovelace', email: 'ada@example.com' } },
-          }],
-        }))
+        return Promise.resolve(
+          jsonResponse({
+            items: [
+              {
+                metadata: { name: 'mbr-1', creationTimestamp: '2024-01-01T00:00:00Z' },
+                spec: { userRef: { name: 'user-1' }, roles: [{ name: 'viewer' }] },
+                status: {
+                  user: {
+                    givenName: 'Ada',
+                    familyName: 'Lovelace',
+                    email: 'ada@example.com',
+                    avatarUrl: 'https://cdn.example.com/ada.png',
+                  },
+                },
+              },
+            ],
+          })
+        )
       }
-      return Promise.resolve(jsonResponse({
-        items: [{
-          metadata: { name: 'inv-1', creationTimestamp: '2024-02-01T00:00:00Z' },
-          spec: { givenName: 'Bob', familyName: 'Builder', email: 'bob@example.com', roles: [{ name: 'editor' }], state: 'Pending' },
-        }],
-      }))
+      return Promise.resolve(
+        jsonResponse({
+          items: [
+            {
+              metadata: { name: 'inv-1', creationTimestamp: '2024-02-01T00:00:00Z' },
+              spec: {
+                givenName: 'Bob',
+                familyName: 'Builder',
+                email: 'bob@example.com',
+                roles: [{ name: 'editor' }],
+                state: 'Pending',
+              },
+            },
+          ],
+        })
+      )
     })
 
     const result = await callOrgMembers('acme')
     expect(result).toHaveLength(2)
     expect(result.find((m: unknown) => (m as { type: string }).type === 'member')).toMatchObject({
-      name: 'mbr-1', email: 'ada@example.com', givenName: 'Ada', roles: ['viewer'], type: 'member',
+      name: 'mbr-1',
+      email: 'ada@example.com',
+      givenName: 'Ada',
+      roles: ['viewer'],
+      type: 'member',
       userName: 'user-1',
+      avatarUrl: 'https://cdn.example.com/ada.png',
     })
-    expect(result.find((m: unknown) => (m as { type: string }).type === 'invitation')).toMatchObject({
-      name: 'inv-1', email: 'bob@example.com', invitationState: 'Pending', type: 'invitation',
+    expect(
+      result.find((m: unknown) => (m as { type: string }).type === 'invitation')
+    ).toMatchObject({
+      name: 'inv-1',
+      email: 'bob@example.com',
+      invitationState: 'Pending',
+      type: 'invitation',
       userName: null,
+      avatarUrl: null,
     })
     expect(fetchSpy).toHaveBeenCalledTimes(2)
   })
@@ -622,7 +766,11 @@ describe('Query.organizationMembers', () => {
       if (url.includes('organizationmemberships')) {
         return Promise.resolve(new Response('{}', { status: 403 }))
       }
-      return Promise.resolve(jsonResponse({ items: [{ metadata: { name: 'inv-1' }, spec: { email: 'x@y.com', roles: [] } }] }))
+      return Promise.resolve(
+        jsonResponse({
+          items: [{ metadata: { name: 'inv-1' }, spec: { email: 'x@y.com', roles: [] } }],
+        })
+      )
     })
     const result = await callOrgMembers('acme')
     expect(result).toHaveLength(1)
@@ -632,6 +780,83 @@ describe('Query.organizationMembers', () => {
   it('returns empty list when fetch throws', async () => {
     fetchSpy.mockRejectedValue(new Error('network'))
     expect(await callOrgMembers('acme')).toEqual([])
+  })
+})
+
+describe('Organization.members / Organization.projects', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('resolves nested members from the parent organization name', async () => {
+    fetchSpy.mockImplementation((url: string) => {
+      if (url.includes('organizationmemberships')) {
+        return Promise.resolve(
+          jsonResponse({
+            items: [
+              {
+                metadata: { name: 'mbr-1' },
+                spec: { userRef: { name: 'user-1' }, roles: [{ name: 'viewer' }] },
+                status: { user: { email: 'ada@example.com' } },
+              },
+            ],
+          })
+        )
+      }
+      return Promise.resolve(jsonResponse({ items: [] }))
+    })
+
+    const result = await (
+      additionalResolvers.Organization!.members as (
+        p: { name: string },
+        a: unknown,
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown[]>
+    )({ name: 'acme' }, {}, ctx())
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ name: 'mbr-1', email: 'ada@example.com', type: 'member' })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/namespaces/organization-acme/organizationmemberships'),
+      expect.anything()
+    )
+  })
+
+  it('resolves nested projects from the parent organization name', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            metadata: {
+              name: 'proj-1',
+              annotations: { 'kubernetes.io/description': 'Project One' },
+            },
+            spec: { ownerRef: { name: 'acme', kind: 'Organization' } },
+          },
+        ],
+        metadata: {},
+      })
+    )
+
+    const result = await (
+      additionalResolvers.Organization!.projects as (
+        p: { name: string },
+        a: { limit?: number; cursor?: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<{ items: { name: string; organizationName: string }[] }>
+    )({ name: 'acme' }, { limit: 5 }, ctx())
+
+    expect(result.items[0]).toMatchObject({ name: 'proj-1', organizationName: 'acme' })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/organizations/acme/control-plane/apis/resourcemanager.miloapis.com/v1alpha1/projects?limit=5'
+      ),
+      expect.anything()
+    )
   })
 })
 
@@ -645,17 +870,33 @@ describe('Query.projects', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   it('lists all projects', async () => {
-    fetchSpy.mockResolvedValue(jsonResponse({
-      items: [{ metadata: { name: 'proj-a', annotations: {} }, spec: { ownerRef: { name: 'acme' } } }],
-      metadata: {},
-    }))
-    const result = await (additionalResolvers.Query!.projects as (r: null, a: object, c: ReturnType<typeof ctx>) => Promise<{ items: { name: string }[] }>)(null, {}, ctx())
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        items: [
+          { metadata: { name: 'proj-a', annotations: {} }, spec: { ownerRef: { name: 'acme' } } },
+        ],
+        metadata: {},
+      })
+    )
+    const result = await (
+      additionalResolvers.Query!.projects as (
+        r: null,
+        a: object,
+        c: ReturnType<typeof ctx>
+      ) => Promise<{ items: { name: string }[] }>
+    )(null, {}, ctx())
     expect(result.items[0].name).toBe('proj-a')
   })
 
   it('returns empty list on non-ok response', async () => {
     fetchSpy.mockResolvedValue(new Response('{}', { status: 500 }))
-    const result = await (additionalResolvers.Query!.projects as (r: null, a: object, c: ReturnType<typeof ctx>) => Promise<{ items: unknown[] }>)(null, {}, ctx())
+    const result = await (
+      additionalResolvers.Query!.projects as (
+        r: null,
+        a: object,
+        c: ReturnType<typeof ctx>
+      ) => Promise<{ items: unknown[] }>
+    )(null, {}, ctx())
     expect(result.items).toEqual([])
   })
 })
@@ -670,18 +911,35 @@ describe('Query.project', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   it('fetches a single project by name', async () => {
-    fetchSpy.mockResolvedValue(jsonResponse({
-      metadata: { name: 'proj-a', annotations: { 'kubernetes.io/description': 'Alpha' } },
-      spec: { ownerRef: { name: 'acme' } },
-    }))
-    const result = await (additionalResolvers.Query!.project as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<{ name: string; displayName: string } | null>)(null, { name: 'proj-a' }, ctx())
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        metadata: { name: 'proj-a', annotations: { 'kubernetes.io/description': 'Alpha' } },
+        spec: { ownerRef: { name: 'acme' } },
+      })
+    )
+    const result = await (
+      additionalResolvers.Query!.project as (
+        r: null,
+        a: { name: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<{ name: string; displayName: string } | null>
+    )(null, { name: 'proj-a' }, ctx())
     expect(result).toMatchObject({ name: 'proj-a', displayName: 'Alpha' })
-    expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('/projects/proj-a'), expect.anything())
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/projects/proj-a'),
+      expect.anything()
+    )
   })
 
   it('returns null on 404', async () => {
     fetchSpy.mockResolvedValue(new Response('{}', { status: 404 }))
-    const result = await (additionalResolvers.Query!.project as (r: null, a: { name: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { name: 'gone' }, ctx())
+    const result = await (
+      additionalResolvers.Query!.project as (
+        r: null,
+        a: { name: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, { name: 'gone' }, ctx())
     expect(result).toBeNull()
   })
 })
@@ -722,7 +980,10 @@ const mockBucket = (resourceType: string, overrides: Record<string, unknown> = {
 const mockRegistration = (resourceType: string, overrides: Record<string, unknown> = {}) => ({
   metadata: {
     name: `reg-${resourceType}`,
-    annotations: { 'kubernetes.io/display-name': `Display ${resourceType}`, 'kubernetes.io/description': `Desc ${resourceType}` },
+    annotations: {
+      'kubernetes.io/display-name': `Display ${resourceType}`,
+      'kubernetes.io/description': `Desc ${resourceType}`,
+    },
     labels: { 'services.miloapis.com/owner': 'core.miloapis.com' },
   },
   spec: { resourceType, type: 'Allocation' },
@@ -731,21 +992,34 @@ const mockRegistration = (resourceType: string, overrides: Record<string, unknow
 
 describe('Query.orgQuotaBuckets', () => {
   let fetchSpy: ReturnType<typeof vi.fn>
-  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
   afterEach(() => vi.unstubAllGlobals())
 
   const call = (orgName: string) =>
-    (additionalResolvers.Query!.orgQuotaBuckets as (r: null, a: { orgName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { orgName }, ctx())
+    (
+      additionalResolvers.Query!.orgQuotaBuckets as (
+        r: null,
+        a: { orgName: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, { orgName }, ctx())
 
   it('joins buckets with registrations and resolves display names', async () => {
     fetchSpy.mockImplementation((url: string) => {
       if (url.includes('allowancebuckets'))
         return Promise.resolve(jsonResponse({ items: [mockBucket('core.miloapis.com/quotas')] }))
-      return Promise.resolve(jsonResponse({ items: [mockRegistration('core.miloapis.com/quotas')] }))
+      return Promise.resolve(
+        jsonResponse({ items: [mockRegistration('core.miloapis.com/quotas')] })
+      )
     })
-    const result = await call('acme') as { items: unknown[] }
+    const result = (await call('acme')) as { items: unknown[] }
     expect(result.items).toHaveLength(1)
-    expect((result.items[0] as Record<string, unknown>).displayName).toBe('Display core.miloapis.com/quotas')
+    expect((result.items[0] as Record<string, unknown>).displayName).toBe(
+      'Display core.miloapis.com/quotas'
+    )
     expect((result.items[0] as Record<string, unknown>).serviceDisplayName).toBe('Platform Core')
     expect((result.items[0] as Record<string, unknown>).allocated).toBe(3)
     expect(fetchSpy).toHaveBeenCalledTimes(2)
@@ -755,47 +1029,83 @@ describe('Query.orgQuotaBuckets', () => {
     fetchSpy.mockImplementation((url: string) => {
       if (url.includes('allowancebuckets'))
         return Promise.resolve(jsonResponse({ items: [mockBucket('some.com/feature')] }))
-      return Promise.resolve(jsonResponse({ items: [{ ...mockRegistration('some.com/feature'), spec: { resourceType: 'some.com/feature', type: 'Feature' } }] }))
+      return Promise.resolve(
+        jsonResponse({
+          items: [
+            {
+              ...mockRegistration('some.com/feature'),
+              spec: { resourceType: 'some.com/feature', type: 'Feature' },
+            },
+          ],
+        })
+      )
     })
-    const result = await call('acme') as { items: unknown[] }
+    const result = (await call('acme')) as { items: unknown[] }
     expect(result.items).toHaveLength(0)
   })
 
   it('falls back to hardcoded display name when annotation absent', async () => {
     fetchSpy.mockImplementation((url: string) => {
       if (url.includes('allowancebuckets'))
-        return Promise.resolve(jsonResponse({ items: [mockBucket('compute.datumapis.com/instances')] }))
-      return Promise.resolve(jsonResponse({ items: [{ metadata: { name: 'r', annotations: {}, labels: { 'services.miloapis.com/owner': 'compute.datumapis.com' } }, spec: { resourceType: 'compute.datumapis.com/instances', type: 'Allocation' } }] }))
+        return Promise.resolve(
+          jsonResponse({ items: [mockBucket('compute.datumapis.com/instances')] })
+        )
+      return Promise.resolve(
+        jsonResponse({
+          items: [
+            {
+              metadata: {
+                name: 'r',
+                annotations: {},
+                labels: { 'services.miloapis.com/owner': 'compute.datumapis.com' },
+              },
+              spec: { resourceType: 'compute.datumapis.com/instances', type: 'Allocation' },
+            },
+          ],
+        })
+      )
     })
-    const result = await call('acme') as { items: { displayName: string; serviceDisplayName: string }[] }
+    const result = (await call('acme')) as {
+      items: { displayName: string; serviceDisplayName: string }[]
+    }
     expect(result.items[0].displayName).toBe('Instances')
     expect(result.items[0].serviceDisplayName).toBe('Compute')
   })
 
   it('returns empty list when buckets fetch fails', async () => {
     fetchSpy.mockImplementation((url: string) => {
-      if (url.includes('allowancebuckets')) return Promise.resolve(new Response('{}', { status: 403 }))
+      if (url.includes('allowancebuckets'))
+        return Promise.resolve(new Response('{}', { status: 403 }))
       return Promise.resolve(jsonResponse({ items: [] }))
     })
-    const result = await call('acme') as { items: unknown[] }
+    const result = (await call('acme')) as { items: unknown[] }
     expect(result.items).toEqual([])
   })
 
   it('returns empty list on network error', async () => {
     fetchSpy.mockRejectedValue(new Error('network'))
-    const result = await call('acme') as { items: unknown[] }
+    const result = (await call('acme')) as { items: unknown[] }
     expect(result.items).toEqual([])
   })
 })
 
 describe('Query.projectQuotaBuckets', () => {
   let fetchSpy: ReturnType<typeof vi.fn>
-  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
   afterEach(() => vi.unstubAllGlobals())
 
   it('fetches from project control plane', async () => {
     fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
-    const result = await (additionalResolvers.Query!.projectQuotaBuckets as (r: null, a: { projectName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { projectName: 'my-proj' }, ctx()) as { items: unknown[] }
+    const result = (await (
+      additionalResolvers.Query!.projectQuotaBuckets as (
+        r: null,
+        a: { projectName: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, { projectName: 'my-proj' }, ctx())) as { items: unknown[] }
     expect(result.items).toEqual([])
     const urls: string[] = fetchSpy.mock.calls.map((c: unknown[]) => c[0] as string)
     expect(urls.some((u) => u.includes('/projects/my-proj/control-plane'))).toBe(true)
@@ -804,15 +1114,33 @@ describe('Query.projectQuotaBuckets', () => {
 
 describe('Query.orgQuotaGrants', () => {
   let fetchSpy: ReturnType<typeof vi.fn>
-  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
   afterEach(() => vi.unstubAllGlobals())
 
   const call = (orgName: string) =>
-    (additionalResolvers.Query!.orgQuotaGrants as (r: null, a: { orgName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { orgName }, ctx())
+    (
+      additionalResolvers.Query!.orgQuotaGrants as (
+        r: null,
+        a: { orgName: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, { orgName }, ctx())
 
   const mockGrant = () => ({
-    metadata: { name: 'grant-1', namespace: 'organization-acme', creationTimestamp: '2024-01-01T00:00:00Z', labels: {} },
-    spec: { allowances: [{ resourceType: 'core.miloapis.com/quotas', buckets: [{ amount: 5 }, { amount: 3 }] }] },
+    metadata: {
+      name: 'grant-1',
+      namespace: 'organization-acme',
+      creationTimestamp: '2024-01-01T00:00:00Z',
+      labels: {},
+    },
+    spec: {
+      allowances: [
+        { resourceType: 'core.miloapis.com/quotas', buckets: [{ amount: 5 }, { amount: 3 }] },
+      ],
+    },
     status: { conditions: [{ type: 'Active', status: 'True', message: 'ok' }] },
   })
 
@@ -820,9 +1148,17 @@ describe('Query.orgQuotaGrants', () => {
     fetchSpy.mockImplementation((url: string) => {
       if (url.includes('resourcegrants'))
         return Promise.resolve(jsonResponse({ items: [mockGrant()] }))
-      return Promise.resolve(jsonResponse({ items: [mockRegistration('core.miloapis.com/quotas')] }))
+      return Promise.resolve(
+        jsonResponse({ items: [mockRegistration('core.miloapis.com/quotas')] })
+      )
     })
-    const result = await call('acme') as { items: { allowances: { resourceType: string; amount: number; displayName: string }[]; autoCreated: boolean; conditions: unknown[] }[] }
+    const result = (await call('acme')) as {
+      items: {
+        allowances: { resourceType: string; amount: number; displayName: string }[]
+        autoCreated: boolean
+        conditions: unknown[]
+      }[]
+    }
     expect(result.items).toHaveLength(1)
     expect(result.items[0].allowances).toHaveLength(1)
     expect(result.items[0].allowances[0].amount).toBe(8) // 5 + 3
@@ -833,36 +1169,51 @@ describe('Query.orgQuotaGrants', () => {
 
   it('marks autoCreated grants', async () => {
     const autoGrant = {
-      metadata: { name: 'auto-1', namespace: 'organization-acme', labels: { 'quota.miloapis.com/auto-created': 'true' } },
+      metadata: {
+        name: 'auto-1',
+        namespace: 'organization-acme',
+        labels: { 'quota.miloapis.com/auto-created': 'true' },
+      },
       spec: { allowances: [] },
       status: { conditions: [] },
     }
     fetchSpy.mockImplementation((url: string) => {
-      if (url.includes('resourcegrants')) return Promise.resolve(jsonResponse({ items: [autoGrant] }))
+      if (url.includes('resourcegrants'))
+        return Promise.resolve(jsonResponse({ items: [autoGrant] }))
       return Promise.resolve(jsonResponse({ items: [] }))
     })
-    const result = await call('acme') as { items: { autoCreated: boolean }[] }
+    const result = (await call('acme')) as { items: { autoCreated: boolean }[] }
     expect(result.items[0].autoCreated).toBe(true)
   })
 
   it('returns empty list when grants fetch fails', async () => {
     fetchSpy.mockImplementation((url: string) => {
-      if (url.includes('resourcegrants')) return Promise.resolve(new Response('{}', { status: 500 }))
+      if (url.includes('resourcegrants'))
+        return Promise.resolve(new Response('{}', { status: 500 }))
       return Promise.resolve(jsonResponse({ items: [] }))
     })
-    const result = await call('acme') as { items: unknown[] }
+    const result = (await call('acme')) as { items: unknown[] }
     expect(result.items).toEqual([])
   })
 })
 
 describe('Query.projectQuotaGrants', () => {
   let fetchSpy: ReturnType<typeof vi.fn>
-  beforeEach(() => { fetchSpy = vi.fn(); vi.stubGlobal('fetch', fetchSpy) })
+  beforeEach(() => {
+    fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+  })
   afterEach(() => vi.unstubAllGlobals())
 
   it('fetches from project control plane', async () => {
     fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
-    const result = await (additionalResolvers.Query!.projectQuotaGrants as (r: null, a: { projectName: string }, c: ReturnType<typeof ctx>) => Promise<unknown>)(null, { projectName: 'my-proj' }, ctx()) as { items: unknown[] }
+    const result = (await (
+      additionalResolvers.Query!.projectQuotaGrants as (
+        r: null,
+        a: { projectName: string },
+        c: ReturnType<typeof ctx>
+      ) => Promise<unknown>
+    )(null, { projectName: 'my-proj' }, ctx())) as { items: unknown[] }
     expect(result.items).toEqual([])
     const urls: string[] = fetchSpy.mock.calls.map((c: unknown[]) => c[0] as string)
     expect(urls.some((u) => u.includes('/projects/my-proj/control-plane'))).toBe(true)

--- a/src/gateway/graphql/resolvers/index.ts
+++ b/src/gateway/graphql/resolvers/index.ts
@@ -18,4 +18,7 @@ export const additionalResolvers = {
     ...sessionsResolvers.Mutation,
     ...usersResolvers.Mutation,
   },
+  Organization: {
+    ...organizationsResolvers.Organization,
+  },
 }

--- a/src/gateway/graphql/resolvers/organizations.ts
+++ b/src/gateway/graphql/resolvers/organizations.ts
@@ -1,6 +1,11 @@
 import { getOriginalFetch, getK8sServer } from '@/gateway/auth'
 import { log } from '@/shared/utils'
-import { type ResolverContext, getHeader, DESCRIPTION_ANNOTATION, DISPLAY_NAME_ANNOTATION } from './common'
+import {
+  type ResolverContext,
+  getHeader,
+  DESCRIPTION_ANNOTATION,
+  DISPLAY_NAME_ANNOTATION,
+} from './common'
 
 interface UpstreamOrganization {
   metadata?: {
@@ -8,8 +13,17 @@ interface UpstreamOrganization {
     creationTimestamp?: string
     annotations?: Record<string, string>
   }
-  spec?: { type?: string }
-  status?: { conditions?: Array<{ type?: string; status?: string }> }
+  spec?: {
+    type?: string
+    contactInfo?: {
+      businessName?: string
+      name?: string
+      email?: string
+    }
+  }
+  status?: {
+    conditions?: Array<{ type?: string; status?: string; reason?: string; message?: string }>
+  }
 }
 
 interface UpstreamOrganizationList {
@@ -35,7 +49,14 @@ interface UpstreamProjectList {
 interface UpstreamOrganizationMembership {
   metadata?: { name?: string; creationTimestamp?: string }
   spec?: { userRef?: { name?: string }; roles?: Array<{ name: string; namespace?: string }> }
-  status?: { user?: { givenName?: string; familyName?: string; email?: string } }
+  status?: {
+    user?: {
+      givenName?: string
+      familyName?: string
+      email?: string
+      avatarUrl?: string
+    }
+  }
 }
 
 interface UpstreamOrganizationMembershipList {
@@ -75,23 +96,64 @@ interface UpstreamProject {
   metadata?: { annotations?: Record<string, string> }
 }
 
-function mapOrganization(raw: UpstreamOrganization) {
+export interface MappedOrgContactInfo {
+  businessName: string | null
+  name: string | null
+  email: string | null
+}
+
+export interface MappedOrganization {
+  name: string
+  displayName: string
+  type: string
+  createdAt: string | null
+  state: string | null
+  contactInfo: MappedOrgContactInfo | null
+  onboardingComplete: boolean
+  onboardingReason: string | null
+  onboardingMessage: string | null
+}
+
+export interface MappedProject {
+  name: string
+  displayName: string
+  organizationName: string
+  createdAt: string | null
+  state: string | null
+}
+
+function mapOrganization(raw: UpstreamOrganization): MappedOrganization {
   const annotations = raw.metadata?.annotations ?? {}
   const displayName = annotations[DISPLAY_NAME_ANNOTATION] || raw.metadata?.name || ''
   const readyCondition = raw.status?.conditions?.find((c) => c.type === 'Ready')
+  const onboardingCondition = raw.status?.conditions?.find((c) => c.type === 'OnboardingComplete')
+  const contact = raw.spec?.contactInfo
   return {
     name: raw.metadata?.name ?? '',
     displayName,
     type: raw.spec?.type ?? '',
     createdAt: raw.metadata?.creationTimestamp ?? null,
     state: readyCondition?.status ?? null,
+    contactInfo: contact
+      ? {
+          businessName: contact.businessName?.trim() || null,
+          name: contact.name ?? null,
+          email: contact.email ?? null,
+        }
+      : null,
+    onboardingComplete: onboardingCondition?.status === 'True',
+    onboardingReason: onboardingCondition?.reason ?? null,
+    onboardingMessage: onboardingCondition?.message ?? null,
   }
 }
 
-function mapProjectFull(raw: UpstreamProjectFull) {
+function mapProjectFull(raw: UpstreamProjectFull): MappedProject {
   const annotations = raw.metadata?.annotations ?? {}
   const displayName =
-    annotations[DISPLAY_NAME_ANNOTATION] || annotations[DESCRIPTION_ANNOTATION] || raw.metadata?.name || ''
+    annotations[DISPLAY_NAME_ANNOTATION] ||
+    annotations[DESCRIPTION_ANNOTATION] ||
+    raw.metadata?.name ||
+    ''
   const readyCondition = raw.status?.conditions?.find((c) => c.type === 'Ready')
   return {
     name: raw.metadata?.name ?? '',
@@ -102,7 +164,9 @@ function mapProjectFull(raw: UpstreamProjectFull) {
   }
 }
 
-function organizationsURL(params: { name?: string; limit?: number; cursor?: string; search?: string } = {}) {
+function organizationsURL(
+  params: { name?: string; limit?: number; cursor?: string; search?: string } = {}
+) {
   const server = getK8sServer()
   const base = `${server}/apis/resourcemanager.miloapis.com/v1alpha1/organizations`
   if (params.name) return `${base}/${encodeURIComponent(params.name)}`
@@ -213,7 +277,133 @@ async function resolveProjectDisplayNames(
   return displayNames
 }
 
+type OrgMemberResult = {
+  name: string
+  givenName: string | null
+  familyName: string | null
+  email: string
+  roles: string[]
+  type: string
+  invitationState: string | null
+  createdAt: string | null
+  userName: string | null
+  avatarUrl: string | null
+}
+
+type ProjectListResult = {
+  items: MappedProject[]
+  continueToken: string | null
+}
+
+async function fetchOrgProjects(
+  orgName: string,
+  args: { limit?: number; cursor?: string },
+  context: ResolverContext
+): Promise<ProjectListResult> {
+  const authorization = getHeader(context, 'authorization')
+  try {
+    const url = orgProjectsURL(orgName, { limit: args.limit, cursor: args.cursor })
+    const r = await getOriginalFetch()(url, {
+      headers: {
+        ...(authorization ? { Authorization: authorization } : {}),
+        Accept: 'application/json',
+      },
+    })
+    if (!r.ok) {
+      log.warn('milo organizationProjects fetch failed', { orgName, status: r.status })
+      return { items: [], continueToken: null }
+    }
+    const body = (await r.json()) as UpstreamProjectList
+    return {
+      items: (body.items ?? []).map(mapProjectFull),
+      continueToken: body.metadata?.continue ?? null,
+    }
+  } catch (error) {
+    log.error('organizationProjects resolver failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { items: [], continueToken: null }
+  }
+}
+
+async function fetchOrgMembers(
+  orgName: string,
+  context: ResolverContext
+): Promise<OrgMemberResult[]> {
+  const authorization = getHeader(context, 'authorization')
+  const headers = {
+    ...(authorization ? { Authorization: authorization } : {}),
+    Accept: 'application/json',
+  }
+  const fetchFn = getOriginalFetch()
+  try {
+    const [membershipsRes, invitationsRes] = await Promise.all([
+      fetchFn(orgMembershipsURL(orgName), { headers }),
+      fetchFn(orgInvitationsURL(orgName), { headers }),
+    ])
+
+    const result: OrgMemberResult[] = []
+
+    if (membershipsRes.ok) {
+      const body = (await membershipsRes.json()) as UpstreamOrganizationMembershipList
+      for (const m of body.items ?? []) {
+        result.push({
+          name: m.metadata?.name ?? '',
+          givenName: m.status?.user?.givenName ?? null,
+          familyName: m.status?.user?.familyName ?? null,
+          email: m.status?.user?.email ?? '',
+          roles: (m.spec?.roles ?? []).map((r) => r.name),
+          type: 'member',
+          invitationState: null,
+          createdAt: m.metadata?.creationTimestamp ?? null,
+          userName: m.spec?.userRef?.name ?? null,
+          avatarUrl: m.status?.user?.avatarUrl ?? null,
+        })
+      }
+    } else {
+      log.warn('milo orgMemberships fetch failed', { orgName, status: membershipsRes.status })
+    }
+
+    if (invitationsRes.ok) {
+      const body = (await invitationsRes.json()) as UpstreamUserInvitationList
+      for (const inv of body.items ?? []) {
+        result.push({
+          name: inv.metadata?.name ?? '',
+          givenName: inv.spec?.givenName ?? null,
+          familyName: inv.spec?.familyName ?? null,
+          email: inv.spec?.email ?? '',
+          roles: (inv.spec?.roles ?? []).map((r) => r.name),
+          type: 'invitation',
+          invitationState: inv.spec?.state ?? null,
+          createdAt: inv.metadata?.creationTimestamp ?? null,
+          userName: null,
+          avatarUrl: null,
+        })
+      }
+    } else {
+      log.warn('milo orgInvitations fetch failed', { orgName, status: invitationsRes.status })
+    }
+
+    return result
+  } catch (error) {
+    log.error('organizationMembers resolver failed', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return []
+  }
+}
+
 export const organizationsResolvers = {
+  Organization: {
+    members: (parent: { name: string }, _args: unknown, context: ResolverContext) =>
+      fetchOrgMembers(parent.name, context),
+    projects: (
+      parent: { name: string },
+      args: { limit?: number; cursor?: string },
+      context: ResolverContext
+    ) => fetchOrgProjects(parent.name, args, context),
+  },
+
   Query: {
     organizations: async (
       _root: unknown,
@@ -222,9 +412,16 @@ export const organizationsResolvers = {
     ) => {
       const authorization = getHeader(context, 'authorization')
       try {
-        const url = organizationsURL({ limit: args.limit, cursor: args.cursor, search: args.search })
+        const url = organizationsURL({
+          limit: args.limit,
+          cursor: args.cursor,
+          search: args.search,
+        })
         const r = await getOriginalFetch()(url, {
-          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+          headers: {
+            ...(authorization ? { Authorization: authorization } : {}),
+            Accept: 'application/json',
+          },
         })
         if (!r.ok) {
           log.warn('milo organizations fetch failed', { status: r.status, url })
@@ -236,7 +433,9 @@ export const organizationsResolvers = {
           continueToken: body.metadata?.continue ?? null,
         }
       } catch (error) {
-        log.error('organizations resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        log.error('organizations resolver failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
         return { items: [], continueToken: null }
       }
     },
@@ -246,7 +445,10 @@ export const organizationsResolvers = {
       try {
         const url = organizationsURL({ name: args.name })
         const r = await getOriginalFetch()(url, {
-          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+          headers: {
+            ...(authorization ? { Authorization: authorization } : {}),
+            Accept: 'application/json',
+          },
         })
         if (!r.ok) {
           log.warn('milo organization fetch failed', { name: args.name, status: r.status })
@@ -254,101 +456,21 @@ export const organizationsResolvers = {
         }
         return mapOrganization((await r.json()) as UpstreamOrganization)
       } catch (error) {
-        log.error('organization resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        log.error('organization resolver failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
         return null
       }
     },
 
-    organizationProjects: async (
+    organizationProjects: (
       _root: unknown,
       args: { orgName: string; limit?: number; cursor?: string },
       context: ResolverContext
-    ) => {
-      const authorization = getHeader(context, 'authorization')
-      try {
-        const url = orgProjectsURL(args.orgName, { limit: args.limit, cursor: args.cursor })
-        const r = await getOriginalFetch()(url, {
-          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
-        })
-        if (!r.ok) {
-          log.warn('milo organizationProjects fetch failed', { orgName: args.orgName, status: r.status })
-          return { items: [], continueToken: null }
-        }
-        const body = (await r.json()) as UpstreamProjectList
-        return {
-          items: (body.items ?? []).map(mapProjectFull),
-          continueToken: body.metadata?.continue ?? null,
-        }
-      } catch (error) {
-        log.error('organizationProjects resolver failed', { error: error instanceof Error ? error.message : String(error) })
-        return { items: [], continueToken: null }
-      }
-    },
+    ) => fetchOrgProjects(args.orgName, { limit: args.limit, cursor: args.cursor }, context),
 
-    organizationMembers: async (
-      _root: unknown,
-      args: { orgName: string },
-      context: ResolverContext
-    ) => {
-      const authorization = getHeader(context, 'authorization')
-      const headers = { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' }
-      const fetchFn = getOriginalFetch()
-      try {
-        const [membershipsRes, invitationsRes] = await Promise.all([
-          fetchFn(orgMembershipsURL(args.orgName), { headers }),
-          fetchFn(orgInvitationsURL(args.orgName), { headers }),
-        ])
-
-        const result: {
-          name: string; givenName: string | null; familyName: string | null; email: string
-          roles: string[]; type: string; invitationState: string | null; createdAt: string | null
-          userName: string | null
-        }[] = []
-
-        if (membershipsRes.ok) {
-          const body = (await membershipsRes.json()) as UpstreamOrganizationMembershipList
-          for (const m of body.items ?? []) {
-            result.push({
-              name: m.metadata?.name ?? '',
-              givenName: m.status?.user?.givenName ?? null,
-              familyName: m.status?.user?.familyName ?? null,
-              email: m.status?.user?.email ?? '',
-              roles: (m.spec?.roles ?? []).map((r) => r.name),
-              type: 'member',
-              invitationState: null,
-              createdAt: m.metadata?.creationTimestamp ?? null,
-              userName: m.spec?.userRef?.name ?? null,
-            })
-          }
-        } else {
-          log.warn('milo orgMemberships fetch failed', { orgName: args.orgName, status: membershipsRes.status })
-        }
-
-        if (invitationsRes.ok) {
-          const body = (await invitationsRes.json()) as UpstreamUserInvitationList
-          for (const inv of body.items ?? []) {
-            result.push({
-              name: inv.metadata?.name ?? '',
-              givenName: inv.spec?.givenName ?? null,
-              familyName: inv.spec?.familyName ?? null,
-              email: inv.spec?.email ?? '',
-              roles: (inv.spec?.roles ?? []).map((r) => r.name),
-              type: 'invitation',
-              invitationState: inv.spec?.state ?? null,
-              createdAt: inv.metadata?.creationTimestamp ?? null,
-              userName: null,
-            })
-          }
-        } else {
-          log.warn('milo orgInvitations fetch failed', { orgName: args.orgName, status: invitationsRes.status })
-        }
-
-        return result
-      } catch (error) {
-        log.error('organizationMembers resolver failed', { error: error instanceof Error ? error.message : String(error) })
-        return []
-      }
-    },
+    organizationMembers: (_root: unknown, args: { orgName: string }, context: ResolverContext) =>
+      fetchOrgMembers(args.orgName, context),
 
     projects: async (
       _root: unknown,
@@ -359,7 +481,10 @@ export const organizationsResolvers = {
       try {
         const url = projectsListURL({ limit: args.limit, cursor: args.cursor, search: args.search })
         const r = await getOriginalFetch()(url, {
-          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+          headers: {
+            ...(authorization ? { Authorization: authorization } : {}),
+            Accept: 'application/json',
+          },
         })
         if (!r.ok) {
           log.warn('milo projects fetch failed', { status: r.status, url })
@@ -371,7 +496,9 @@ export const organizationsResolvers = {
           continueToken: body.metadata?.continue ?? null,
         }
       } catch (error) {
-        log.error('projects resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        log.error('projects resolver failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
         return { items: [], continueToken: null }
       }
     },
@@ -380,7 +507,10 @@ export const organizationsResolvers = {
       const authorization = getHeader(context, 'authorization')
       try {
         const r = await getOriginalFetch()(projectURL(args.name), {
-          headers: { ...(authorization ? { Authorization: authorization } : {}), Accept: 'application/json' },
+          headers: {
+            ...(authorization ? { Authorization: authorization } : {}),
+            Accept: 'application/json',
+          },
         })
         if (!r.ok) {
           log.warn('milo project fetch failed', { name: args.name, status: r.status })
@@ -388,7 +518,9 @@ export const organizationsResolvers = {
         }
         return mapProjectFull((await r.json()) as UpstreamProjectFull)
       } catch (error) {
-        log.error('project resolver failed', { error: error instanceof Error ? error.message : String(error) })
+        log.error('project resolver failed', {
+          error: error instanceof Error ? error.message : String(error),
+        })
         return null
       }
     },

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -153,6 +153,15 @@ export const additionalTypeDefs = /* GraphQL */ `
     onboardedAt: String
   }
 
+  type OrgContactInfo {
+    "Legal / company name from spec.contactInfo.businessName."
+    businessName: String
+    "Primary contact name from spec.contactInfo.name."
+    name: String
+    "Primary contact email from spec.contactInfo.email."
+    email: String
+  }
+
   type Organization {
     "metadata.name — the stable organization ID."
     name: String!
@@ -163,6 +172,18 @@ export const additionalTypeDefs = /* GraphQL */ `
     createdAt: String
     "Status of the Ready condition."
     state: String
+    "Contact details from spec.contactInfo."
+    contactInfo: OrgContactInfo
+    "True when the OnboardingComplete condition status is True."
+    onboardingComplete: Boolean!
+    "Reason from the OnboardingComplete condition."
+    onboardingReason: String
+    "Human-readable message from the OnboardingComplete condition."
+    onboardingMessage: String
+    "Members and pending invitations for this organization."
+    members: [OrgMember!]!
+    "Projects owned by this organization (via its control plane)."
+    projects(limit: Int, cursor: String): ProjectList!
   }
 
   type OrganizationList {
@@ -203,6 +224,8 @@ export const additionalTypeDefs = /* GraphQL */ `
     createdAt: String
     "The member's user resource name. Null for invitations, which have no user yet."
     userName: String
+    "Avatar URL from the membership user status. Null for invitations."
+    avatarUrl: String
   }
 
   type QuotaBucket {
@@ -306,12 +329,22 @@ export const additionalTypeDefs = /* GraphQL */ `
     Contact data for each membership. Resolves all contacts in parallel.
     fieldSelector supports standard Kubernetes field selectors.
     """
-    contactGroupMembershipsWithContacts(namespace: String, fieldSelector: String, limit: Int, cursor: String): EnrichedContactGroupMembershipList!
+    contactGroupMembershipsWithContacts(
+      namespace: String
+      fieldSelector: String
+      limit: Int
+      cursor: String
+    ): EnrichedContactGroupMembershipList!
     """
     Lists ContactGroupMemberships in the given namespace, enriched with full
     ContactGroup data for each membership. Resolves all contact groups in parallel.
     """
-    contactMembershipsWithGroups(namespace: String, fieldSelector: String, limit: Int, cursor: String): EnrichedContactMembershipList!
+    contactMembershipsWithGroups(
+      namespace: String
+      fieldSelector: String
+      limit: Int
+      cursor: String
+    ): EnrichedContactMembershipList!
     """
     Batch-fetches User summaries by name. Fetches run in parallel; individual
     lookup failures return null for that entry (filtered from the result).


### PR DESCRIPTION
## Summary

Staff portal needs richer org list and overview data without a pile of per-org REST round trips. This nests the fields that overview already wants on `Organization` itself: contact info, onboarding status, members (with avatars), and projects.

Existing top-level members/projects queries stay in place. Field resolvers reuse the same loaders so behavior stays consistent.

## Test plan

- [x] Unit tests pass (`resolvers.test.ts` coverage for nested members/projects/onboarding)
- [x] Query an org with `contactInfo`, `onboardingComplete`, `members`, and `projects` in one request
- [x] Confirm invitations still appear in `members` with null `userName` / `avatarUrl`
- [x] Confirm project pagination (`limit` / `cursor`) still works on the nested field
- [x] Smoke staff-portal org list/overview against a gateway running this branch

## Notes for reviewers

Companion to staff-portal `feat/org-overview-enrichment`. Deploy gateway first (or together) so the portal can read the new fields.