### PR TITLE
feat: Enrich Project with org display and billing fields

### DIFF
--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -55,6 +55,100 @@ const jsonResponse = (body: unknown, status = 200) =>
     headers: { 'content-type': 'application/json' },
   })
 
+/** Single Organization resource — used when project resolvers enrich owning orgs. */
+const acmeOrganization = () =>
+  jsonResponse({
+    metadata: {
+      name: 'acme',
+      annotations: { 'kubernetes.io/display-name': 'Acme Corp' },
+    },
+    spec: {
+      type: 'Standard',
+      contactInfo: { businessName: 'Acme LLC', name: 'Ada', email: 'ada@acme.test' },
+    },
+  })
+
+/**
+ * Routes project-list / project / org GETs so enrichment lookups don't collide
+ * with the primary list response (same pattern as routedFetch for consumers).
+ */
+const projectOrgRoutedFetch = (routes: {
+  projectsList?: Response
+  projectByName?: Record<string, Response>
+  organizations?: Record<string, Response>
+  orgProjects?: Response
+  billingBindings?: Record<string, Response>
+  billingAccounts?: Record<string, Response>
+  fallback?: Response
+}) =>
+  vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+    if (url.includes('/billingaccountbindings')) {
+      const orgMatch = url.match(/\/organizations\/([^/]+)\/control-plane/)
+      const orgName = orgMatch ? decodeURIComponent(orgMatch[1]) : ''
+      return Promise.resolve(routes.billingBindings?.[orgName] ?? jsonResponse({ items: [] }))
+    }
+    if (url.includes('/billingaccounts')) {
+      const orgMatch = url.match(/\/organizations\/([^/]+)\/control-plane/)
+      const orgName = orgMatch ? decodeURIComponent(orgMatch[1]) : ''
+      return Promise.resolve(routes.billingAccounts?.[orgName] ?? jsonResponse({ items: [] }))
+    }
+    if (url.includes('/control-plane/') && url.includes('/projects')) {
+      return Promise.resolve(routes.orgProjects ?? jsonResponse({ items: [] }))
+    }
+    const orgMatch = url.match(/\/organizations\/([^/?]+)$/)
+    if (orgMatch) {
+      const name = decodeURIComponent(orgMatch[1])
+      return Promise.resolve(
+        routes.organizations?.[name] ?? routes.fallback ?? new Response('{}', { status: 404 })
+      )
+    }
+    const projectMatch = url.match(/\/projects\/([^/?]+)$/)
+    if (projectMatch && !url.includes('/control-plane/')) {
+      const name = decodeURIComponent(projectMatch[1])
+      return Promise.resolve(
+        routes.projectByName?.[name] ?? routes.fallback ?? new Response('{}', { status: 404 })
+      )
+    }
+    if (url.includes('/projects')) {
+      return Promise.resolve(routes.projectsList ?? jsonResponse({ items: [] }))
+    }
+    return Promise.resolve(routes.fallback ?? jsonResponse({ items: [] }))
+  })
+
+const acmeBillingWithPayment = () => ({
+  billingBindings: {
+    acme: jsonResponse({
+      items: [
+        {
+          spec: {
+            projectRef: { name: 'proj-a' },
+            billingAccountRef: { name: 'ba-1' },
+          },
+          status: { phase: 'Active' },
+        },
+        {
+          spec: {
+            projectRef: { name: 'proj-1' },
+            billingAccountRef: { name: 'ba-1' },
+          },
+          status: { phase: 'Active' },
+        },
+      ],
+    }),
+  },
+  billingAccounts: {
+    acme: jsonResponse({
+      items: [
+        {
+          metadata: { name: 'ba-1' },
+          spec: { defaultPaymentMethodRef: { name: 'pm-1' } },
+        },
+      ],
+    }),
+  },
+})
+
 const callSessions = (args: { userID?: string } = {}, context: ReturnType<typeof ctx> = ctx()) =>
   (additionalResolvers.Query!.sessions as SessionsResolver)(null, args, context)
 
@@ -561,11 +655,38 @@ describe('Query.organizations', () => {
     })
   })
 
-  it('passes fieldSelector when search is provided', async () => {
-    fetchSpy.mockResolvedValue(jsonResponse({ items: [] }))
-    await callOrganizations({ search: 'acme' })
+  it('substring-searches name, displayName, and company across upstream pages', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse({
+        items: [
+          {
+            metadata: {
+              name: 'other',
+              annotations: { 'kubernetes.io/display-name': 'Other Co' },
+            },
+            spec: { type: 'Standard' },
+          },
+          {
+            metadata: {
+              name: 'dtn-acme',
+              annotations: { 'kubernetes.io/display-name': 'Acme Widget' },
+            },
+            spec: {
+              type: 'Standard',
+              contactInfo: { businessName: 'Acme LLC' },
+            },
+          },
+        ],
+        metadata: {},
+      })
+    )
+    const result = (await callOrganizations({ search: 'acme', limit: 10 })) as {
+      items: { name: string; displayName: string }[]
+    }
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]).toMatchObject({ name: 'dtn-acme', displayName: 'Acme Widget' })
     expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('fieldSelector=metadata.name%3Dacme'),
+      expect.stringContaining('/organizations?limit=100'),
       expect.anything()
     )
   })
@@ -642,8 +763,8 @@ describe('Query.organizationProjects', () => {
     )(null, args, ctx())
 
   it('fetches projects via the org control plane URL', async () => {
-    fetchSpy.mockResolvedValue(
-      jsonResponse({
+    fetchSpy = projectOrgRoutedFetch({
+      orgProjects: jsonResponse({
         items: [
           {
             metadata: {
@@ -654,15 +775,31 @@ describe('Query.organizationProjects', () => {
           },
         ],
         metadata: {},
-      })
-    )
+      }),
+      organizations: { acme: acmeOrganization() },
+      ...acmeBillingWithPayment(),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
     const result = (await callOrgProjects({ orgName: 'acme' })) as {
-      items: { name: string; displayName: string; organizationName: string }[]
+      items: {
+        name: string
+        displayName: string
+        organizationName: string
+        organizationDisplayName: string
+        organizationBusinessName: string | null
+        hasActiveBillingAccount: boolean
+        billingAccountName: string | null
+      }[]
     }
     expect(result.items[0]).toMatchObject({
       name: 'proj-1',
       displayName: 'Project One',
       organizationName: 'acme',
+      organizationDisplayName: 'Acme Corp',
+      organizationBusinessName: 'Acme LLC',
+      hasActiveBillingAccount: true,
+      billingAccountName: 'ba-1',
     })
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -827,8 +964,8 @@ describe('Organization.members / Organization.projects', () => {
   })
 
   it('resolves nested projects from the parent organization name', async () => {
-    fetchSpy.mockResolvedValue(
-      jsonResponse({
+    fetchSpy = projectOrgRoutedFetch({
+      orgProjects: jsonResponse({
         items: [
           {
             metadata: {
@@ -839,18 +976,34 @@ describe('Organization.members / Organization.projects', () => {
           },
         ],
         metadata: {},
-      })
-    )
+      }),
+      organizations: { acme: acmeOrganization() },
+      ...acmeBillingWithPayment(),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
 
     const result = await (
       additionalResolvers.Organization!.projects as (
         p: { name: string },
         a: { limit?: number; cursor?: string },
         c: ReturnType<typeof ctx>
-      ) => Promise<{ items: { name: string; organizationName: string }[] }>
+      ) => Promise<{
+        items: {
+          name: string
+          organizationName: string
+          hasActiveBillingAccount: boolean
+        }[]
+      }>
     )({ name: 'acme' }, { limit: 5 }, ctx())
 
-    expect(result.items[0]).toMatchObject({ name: 'proj-1', organizationName: 'acme' })
+    expect(result.items[0]).toMatchObject({
+      name: 'proj-1',
+      organizationName: 'acme',
+      organizationDisplayName: 'Acme Corp',
+      organizationBusinessName: 'Acme LLC',
+      hasActiveBillingAccount: true,
+      billingAccountName: 'ba-1',
+    })
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         '/organizations/acme/control-plane/apis/resourcemanager.miloapis.com/v1alpha1/projects?limit=5'
@@ -870,22 +1023,40 @@ describe('Query.projects', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   it('lists all projects', async () => {
-    fetchSpy.mockResolvedValue(
-      jsonResponse({
+    fetchSpy = projectOrgRoutedFetch({
+      projectsList: jsonResponse({
         items: [
           { metadata: { name: 'proj-a', annotations: {} }, spec: { ownerRef: { name: 'acme' } } },
         ],
         metadata: {},
-      })
-    )
+      }),
+      organizations: { acme: acmeOrganization() },
+      ...acmeBillingWithPayment(),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
     const result = await (
       additionalResolvers.Query!.projects as (
         r: null,
         a: object,
         c: ReturnType<typeof ctx>
-      ) => Promise<{ items: { name: string }[] }>
+      ) => Promise<{
+        items: {
+          name: string
+          organizationDisplayName: string
+          organizationBusinessName: string | null
+          hasActiveBillingAccount: boolean
+          billingAccountName: string | null
+        }[]
+      }>
     )(null, {}, ctx())
-    expect(result.items[0].name).toBe('proj-a')
+    expect(result.items[0]).toMatchObject({
+      name: 'proj-a',
+      organizationDisplayName: 'Acme Corp',
+      organizationBusinessName: 'Acme LLC',
+      hasActiveBillingAccount: true,
+      billingAccountName: 'ba-1',
+    })
   })
 
   it('returns empty list on non-ok response', async () => {
@@ -911,20 +1082,40 @@ describe('Query.project', () => {
   afterEach(() => vi.unstubAllGlobals())
 
   it('fetches a single project by name', async () => {
-    fetchSpy.mockResolvedValue(
-      jsonResponse({
-        metadata: { name: 'proj-a', annotations: { 'kubernetes.io/description': 'Alpha' } },
-        spec: { ownerRef: { name: 'acme' } },
-      })
-    )
+    fetchSpy = projectOrgRoutedFetch({
+      projectByName: {
+        'proj-a': jsonResponse({
+          metadata: { name: 'proj-a', annotations: { 'kubernetes.io/description': 'Alpha' } },
+          spec: { ownerRef: { name: 'acme' } },
+        }),
+      },
+      organizations: { acme: acmeOrganization() },
+      ...acmeBillingWithPayment(),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
     const result = await (
       additionalResolvers.Query!.project as (
         r: null,
         a: { name: string },
         c: ReturnType<typeof ctx>
-      ) => Promise<{ name: string; displayName: string } | null>
+      ) => Promise<{
+        name: string
+        displayName: string
+        organizationDisplayName: string
+        organizationBusinessName: string | null
+        hasActiveBillingAccount: boolean
+        billingAccountName: string | null
+      } | null>
     )(null, { name: 'proj-a' }, ctx())
-    expect(result).toMatchObject({ name: 'proj-a', displayName: 'Alpha' })
+    expect(result).toMatchObject({
+      name: 'proj-a',
+      displayName: 'Alpha',
+      organizationDisplayName: 'Acme Corp',
+      organizationBusinessName: 'Acme LLC',
+      hasActiveBillingAccount: true,
+      billingAccountName: 'ba-1',
+    })
     expect(fetchSpy).toHaveBeenCalledWith(
       expect.stringContaining('/projects/proj-a'),
       expect.anything()

--- a/src/gateway/graphql/resolvers/organizations.ts
+++ b/src/gateway/graphql/resolvers/organizations.ts
@@ -118,8 +118,44 @@ export interface MappedProject {
   name: string
   displayName: string
   organizationName: string
+  organizationDisplayName: string
+  organizationBusinessName: string | null
+  hasActiveBillingAccount: boolean
+  billingAccountName: string | null
   createdAt: string | null
   state: string | null
+}
+
+type OrgEnrichment = {
+  displayName: string
+  businessName: string | null
+}
+
+type BillingEnrichment = {
+  hasActiveBillingAccount: boolean
+  billingAccountName: string | null
+}
+
+interface UpstreamBillingAccount {
+  metadata?: { name?: string; deletionTimestamp?: string }
+  spec?: { defaultPaymentMethodRef?: { name?: string } }
+}
+
+interface UpstreamBillingAccountList {
+  items?: UpstreamBillingAccount[]
+}
+
+interface UpstreamBillingAccountBinding {
+  metadata?: { deletionTimestamp?: string }
+  spec?: {
+    billingAccountRef?: { name?: string }
+    projectRef?: { name?: string }
+  }
+  status?: { phase?: string }
+}
+
+interface UpstreamBillingAccountBindingList {
+  items?: UpstreamBillingAccountBinding[]
 }
 
 function mapOrganization(raw: UpstreamOrganization): MappedOrganization {
@@ -155,27 +191,250 @@ function mapProjectFull(raw: UpstreamProjectFull): MappedProject {
     raw.metadata?.name ||
     ''
   const readyCondition = raw.status?.conditions?.find((c) => c.type === 'Ready')
+  const organizationName = raw.spec?.ownerRef?.name ?? ''
   return {
     name: raw.metadata?.name ?? '',
     displayName,
-    organizationName: raw.spec?.ownerRef?.name ?? '',
+    organizationName,
+    // Defaults until attachOrganizationFields / a single-org enrichment runs.
+    organizationDisplayName: organizationName,
+    organizationBusinessName: null,
+    hasActiveBillingAccount: false,
+    billingAccountName: null,
     createdAt: raw.metadata?.creationTimestamp ?? null,
     state: readyCondition?.status ?? null,
   }
 }
 
-function organizationsURL(
-  params: { name?: string; limit?: number; cursor?: string; search?: string } = {}
-) {
+function orgEnrichmentFromMapped(org: MappedOrganization): OrgEnrichment {
+  return {
+    displayName: org.displayName || org.name,
+    businessName: org.contactInfo?.businessName ?? null,
+  }
+}
+
+function attachOrganizationFields(
+  projects: MappedProject[],
+  orgs: Map<string, OrgEnrichment>
+): MappedProject[] {
+  return projects.map((project) => {
+    const org = orgs.get(project.organizationName)
+    return {
+      ...project,
+      organizationDisplayName: org?.displayName ?? project.organizationName,
+      organizationBusinessName: org?.businessName ?? null,
+    }
+  })
+}
+
+/**
+ * Resolves display/company names for unique owning organizations.
+ *
+ * Mirrors resolveProjectDisplayNames: parallel GETs, per-org failures swallowed
+ * so a single inaccessible org never fails the whole project list.
+ */
+async function resolveOrganizationFields(
+  orgNames: string[],
+  headers: Record<string, string>
+): Promise<Map<string, OrgEnrichment>> {
+  const fetchFn = getOriginalFetch()
+  const result = new Map<string, OrgEnrichment>()
+  const unique = [...new Set(orgNames.filter(Boolean))]
+
+  await Promise.all(
+    unique.map(async (name) => {
+      try {
+        const response = await fetchFn(organizationsURL({ name }), { headers })
+        if (!response.ok) {
+          log.warn('milo organization fetch failed', {
+            organization: name,
+            status: response.status,
+          })
+          return
+        }
+        const mapped = mapOrganization((await response.json()) as UpstreamOrganization)
+        result.set(name, orgEnrichmentFromMapped(mapped))
+      } catch (error) {
+        log.warn('milo organization fetch threw', {
+          organization: name,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    })
+  )
+
+  return result
+}
+
+/**
+ * Per owning-org: load billing bindings + accounts, then mark projects that have
+ * an Active binding to an account with a default payment method.
+ *
+ * Failures are swallowed per-org so a single inaccessible billing namespace
+ * never fails the whole project list.
+ */
+async function resolveBillingFields(
+  projects: MappedProject[],
+  headers: Record<string, string>
+): Promise<MappedProject[]> {
+  if (projects.length === 0) return projects
+
+  const fetchFn = getOriginalFetch()
+  const uniqueOrgs = [...new Set(projects.map((p) => p.organizationName).filter(Boolean))]
+  const billingByProject = new Map<string, BillingEnrichment>()
+
+  await Promise.all(
+    uniqueOrgs.map(async (orgName) => {
+      try {
+        const [bindingsRes, accountsRes] = await Promise.all([
+          fetchFn(orgBillingBindingsURL(orgName), { headers }),
+          fetchFn(orgBillingAccountsURL(orgName), { headers }),
+        ])
+
+        if (!bindingsRes.ok) {
+          log.warn('milo billing bindings fetch failed', {
+            organization: orgName,
+            status: bindingsRes.status,
+          })
+          return
+        }
+        if (!accountsRes.ok) {
+          log.warn('milo billing accounts fetch failed', {
+            organization: orgName,
+            status: accountsRes.status,
+          })
+          return
+        }
+
+        const bindings =
+          ((await bindingsRes.json()) as UpstreamBillingAccountBindingList).items ?? []
+        const accounts = ((await accountsRes.json()) as UpstreamBillingAccountList).items ?? []
+
+        const accountsWithPayment = new Set(
+          accounts
+            .filter(
+              (account) =>
+                !account.metadata?.deletionTimestamp &&
+                Boolean(account.spec?.defaultPaymentMethodRef?.name?.trim())
+            )
+            .map((account) => account.metadata?.name)
+            .filter((name): name is string => Boolean(name))
+        )
+
+        for (const binding of bindings) {
+          if (binding.metadata?.deletionTimestamp) continue
+          const phase = binding.status?.phase
+          if (phase && phase !== 'Active') continue
+
+          const projectName = binding.spec?.projectRef?.name
+          const accountName = binding.spec?.billingAccountRef?.name
+          if (!projectName || !accountName) continue
+          if (!accountsWithPayment.has(accountName)) continue
+
+          billingByProject.set(projectName, {
+            hasActiveBillingAccount: true,
+            billingAccountName: accountName,
+          })
+        }
+      } catch (error) {
+        log.warn('milo billing enrichment threw', {
+          organization: orgName,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    })
+  )
+
+  return projects.map((project) => {
+    const billing = billingByProject.get(project.name)
+    return {
+      ...project,
+      hasActiveBillingAccount: billing?.hasActiveBillingAccount ?? false,
+      billingAccountName: billing?.billingAccountName ?? null,
+    }
+  })
+}
+
+/** Org display/company + billing payment status for a project list page. */
+async function enrichProjects(
+  projects: MappedProject[],
+  headers: Record<string, string>
+): Promise<MappedProject[]> {
+  const orgs = await resolveOrganizationFields(
+    projects.map((item) => item.organizationName),
+    headers
+  )
+  return resolveBillingFields(attachOrganizationFields(projects, orgs), headers)
+}
+
+function organizationsURL(params: { name?: string; limit?: number; cursor?: string } = {}) {
   const server = getK8sServer()
   const base = `${server}/apis/resourcemanager.miloapis.com/v1alpha1/organizations`
   if (params.name) return `${base}/${encodeURIComponent(params.name)}`
   const query = new URLSearchParams()
   if (params.limit) query.set('limit', String(params.limit))
   if (params.cursor) query.set('continue', params.cursor)
-  if (params.search) query.set('fieldSelector', `metadata.name=${params.search}`)
   const qs = query.toString()
   return qs ? `${base}?${qs}` : base
+}
+
+function organizationMatchesSearch(org: MappedOrganization, search: string): boolean {
+  const q = search.toLowerCase()
+  return (
+    org.name.toLowerCase().includes(q) ||
+    org.displayName.toLowerCase().includes(q) ||
+    (org.contactInfo?.businessName?.toLowerCase().includes(q) ?? false) ||
+    (org.contactInfo?.email?.toLowerCase().includes(q) ?? false) ||
+    (org.contactInfo?.name?.toLowerCase().includes(q) ?? false)
+  )
+}
+
+/** Upstream page size while walking for substring search. */
+const ORG_SEARCH_PAGE_SIZE = 100
+/** Cap how many upstream pages a single search walks. */
+const ORG_SEARCH_MAX_PAGES = 20
+
+/**
+ * Substring search across name / displayName / company / contact.
+ * Walks upstream pages until `limit` matches or the page budget is exhausted.
+ */
+async function searchOrganizations(
+  args: { limit?: number; cursor?: string; search: string },
+  headers: Record<string, string>
+): Promise<{ items: MappedOrganization[]; continueToken: string | null }> {
+  const limit = args.limit ?? 50
+  const matches: MappedOrganization[] = []
+  let cursor = args.cursor
+  let nextContinue: string | null = null
+
+  for (let page = 0; page < ORG_SEARCH_MAX_PAGES && matches.length < limit; page++) {
+    const url = organizationsURL({ limit: ORG_SEARCH_PAGE_SIZE, cursor })
+    const r = await getOriginalFetch()(url, { headers })
+    if (!r.ok) {
+      log.warn('milo organizations search fetch failed', { status: r.status, url })
+      break
+    }
+    const body = (await r.json()) as UpstreamOrganizationList
+    for (const raw of body.items ?? []) {
+      const org = mapOrganization(raw)
+      if (!organizationMatchesSearch(org, args.search)) continue
+      matches.push(org)
+      if (matches.length >= limit) break
+    }
+    cursor = body.metadata?.continue ?? undefined
+    nextContinue = cursor ?? null
+    if (!cursor) {
+      nextContinue = null
+      break
+    }
+  }
+
+  return {
+    items: matches.slice(0, limit),
+    // Only expose a continue token when we filled the page and more upstream
+    // data may still exist — callers can pass it back to resume the walk.
+    continueToken: matches.length >= limit ? nextContinue : null,
+  }
 }
 
 function orgProjectsURL(orgName: string, params: { limit?: number; cursor?: string } = {}) {
@@ -189,6 +448,30 @@ function orgProjectsURL(orgName: string, params: { limit?: number; cursor?: stri
   if (params.cursor) query.set('continue', params.cursor)
   const qs = query.toString()
   return qs ? `${base}?${qs}` : base
+}
+
+function orgBillingNamespace(orgName: string) {
+  return `organization-${orgName}`
+}
+
+function orgBillingBindingsURL(orgName: string) {
+  const server = getK8sServer()
+  const ns = orgBillingNamespace(orgName)
+  return (
+    `${server}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/organizations/${encodeURIComponent(orgName)}/control-plane` +
+    `/apis/billing.miloapis.com/v1alpha1/namespaces/${encodeURIComponent(ns)}/billingaccountbindings`
+  )
+}
+
+function orgBillingAccountsURL(orgName: string) {
+  const server = getK8sServer()
+  const ns = orgBillingNamespace(orgName)
+  return (
+    `${server}/apis/resourcemanager.miloapis.com/v1alpha1` +
+    `/organizations/${encodeURIComponent(orgName)}/control-plane` +
+    `/apis/billing.miloapis.com/v1alpha1/namespaces/${encodeURIComponent(ns)}/billingaccounts`
+  )
 }
 
 function orgMembershipsURL(orgName: string) {
@@ -301,21 +584,21 @@ async function fetchOrgProjects(
   context: ResolverContext
 ): Promise<ProjectListResult> {
   const authorization = getHeader(context, 'authorization')
+  const headers = {
+    ...(authorization ? { Authorization: authorization } : {}),
+    Accept: 'application/json',
+  }
   try {
     const url = orgProjectsURL(orgName, { limit: args.limit, cursor: args.cursor })
-    const r = await getOriginalFetch()(url, {
-      headers: {
-        ...(authorization ? { Authorization: authorization } : {}),
-        Accept: 'application/json',
-      },
-    })
+    const r = await getOriginalFetch()(url, { headers })
     if (!r.ok) {
       log.warn('milo organizationProjects fetch failed', { orgName, status: r.status })
       return { items: [], continueToken: null }
     }
     const body = (await r.json()) as UpstreamProjectList
+    const items = (body.items ?? []).map(mapProjectFull)
     return {
-      items: (body.items ?? []).map(mapProjectFull),
+      items: await enrichProjects(items, headers),
       continueToken: body.metadata?.continue ?? null,
     }
   } catch (error) {
@@ -411,18 +694,24 @@ export const organizationsResolvers = {
       context: ResolverContext
     ) => {
       const authorization = getHeader(context, 'authorization')
+      const headers = {
+        ...(authorization ? { Authorization: authorization } : {}),
+        Accept: 'application/json',
+      }
       try {
+        const search = args.search?.trim()
+        if (search) {
+          return await searchOrganizations(
+            { limit: args.limit, cursor: args.cursor, search },
+            headers
+          )
+        }
+
         const url = organizationsURL({
           limit: args.limit,
           cursor: args.cursor,
-          search: args.search,
         })
-        const r = await getOriginalFetch()(url, {
-          headers: {
-            ...(authorization ? { Authorization: authorization } : {}),
-            Accept: 'application/json',
-          },
-        })
+        const r = await getOriginalFetch()(url, { headers })
         if (!r.ok) {
           log.warn('milo organizations fetch failed', { status: r.status, url })
           return { items: [], continueToken: null }
@@ -478,21 +767,21 @@ export const organizationsResolvers = {
       context: ResolverContext
     ) => {
       const authorization = getHeader(context, 'authorization')
+      const headers = {
+        ...(authorization ? { Authorization: authorization } : {}),
+        Accept: 'application/json',
+      }
       try {
         const url = projectsListURL({ limit: args.limit, cursor: args.cursor, search: args.search })
-        const r = await getOriginalFetch()(url, {
-          headers: {
-            ...(authorization ? { Authorization: authorization } : {}),
-            Accept: 'application/json',
-          },
-        })
+        const r = await getOriginalFetch()(url, { headers })
         if (!r.ok) {
           log.warn('milo projects fetch failed', { status: r.status, url })
           return { items: [], continueToken: null }
         }
         const body = (await r.json()) as UpstreamProjectList
+        const items = (body.items ?? []).map(mapProjectFull)
         return {
-          items: (body.items ?? []).map(mapProjectFull),
+          items: await enrichProjects(items, headers),
           continueToken: body.metadata?.continue ?? null,
         }
       } catch (error) {
@@ -505,18 +794,19 @@ export const organizationsResolvers = {
 
     project: async (_root: unknown, args: { name: string }, context: ResolverContext) => {
       const authorization = getHeader(context, 'authorization')
+      const headers = {
+        ...(authorization ? { Authorization: authorization } : {}),
+        Accept: 'application/json',
+      }
       try {
-        const r = await getOriginalFetch()(projectURL(args.name), {
-          headers: {
-            ...(authorization ? { Authorization: authorization } : {}),
-            Accept: 'application/json',
-          },
-        })
+        const r = await getOriginalFetch()(projectURL(args.name), { headers })
         if (!r.ok) {
           log.warn('milo project fetch failed', { name: args.name, status: r.status })
           return null
         }
-        return mapProjectFull((await r.json()) as UpstreamProjectFull)
+        const project = mapProjectFull((await r.json()) as UpstreamProjectFull)
+        const [enriched] = await enrichProjects([project], headers)
+        return enriched
       } catch (error) {
         log.error('project resolver failed', {
           error: error instanceof Error ? error.message : String(error),

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -199,6 +199,14 @@ export const additionalTypeDefs = /* GraphQL */ `
     displayName: String!
     "Name of the owning organization."
     organizationName: String!
+    "Owning organization's display name (kubernetes.io/display-name), falling back to organizationName."
+    organizationDisplayName: String!
+    "Owning organization's company / legal name from contactInfo.businessName."
+    organizationBusinessName: String
+    "True when the project has an Active billing-account binding to an account with a default payment method."
+    hasActiveBillingAccount: Boolean!
+    "Bound billing account name when hasActiveBillingAccount is true."
+    billingAccountName: String
     createdAt: String
     "Status of the Ready condition."
     state: String
@@ -355,7 +363,11 @@ export const additionalTypeDefs = /* GraphQL */ `
     user(id: String!): User
     "Lists UserIdentity resources scoped to the given user."
     userIdentities(userID: String!): [UserIdentity!]!
-    "Lists all organizations the caller can access."
+    """
+    Lists all organizations the caller can access. When \`search\` is set, matches
+    substring against name, displayName, company, and contact fields (walks
+    upstream pages until \`limit\` matches).
+    """
     organizations(limit: Int, cursor: String, search: String): OrganizationList!
     "Returns a single organization by name."
     organization(name: String!): Organization


### PR DESCRIPTION
## Summary

Project list UIs in staff portal need owning-org display names, company names, and whether a project has an active billing account. Until now that meant joining a full org catalog on the client.

This enriches the `Project` GraphQL type with those fields (batched org and billing-binding lookups in the gateway), and fixes the `organizations()` search description to use a block string so the schema parses.

## Test plan

- [x] Gateway tests pass for `Query.projects`, `Query.project`, and `organizationProjects`
- [x] Project list returns `organizationDisplayName`, `organizationBusinessName`, `hasActiveBillingAccount`, and `billingAccountName`
- [x] Schema introspection succeeds (no unterminated string on `organizations`)
- [x] Staff-portal project list can drop its client-side org join once this ships