### PR TITLE
feat: add per-operation latency dashboard and alert

### DIFF
--- a/config/components/observability/alerts/slow-operations.yaml
+++ b/config/components/observability/alerts/slow-operations.yaml
@@ -1,0 +1,24 @@
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: graphql-gateway-slow-operations
+spec:
+  groups:
+    - name: graphql-gateway-latency
+      rules:
+        - alert: GraphQLGatewaySlowOperation
+          expr: |
+            histogram_quantile(0.95, sum by (le, operationName) (rate(graphql_envelop_request_duration_bucket[10m]))) > 2
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              GraphQL operation {{ $labels.operationName }} has a p95
+              latency of {{ $value | humanizeDuration }}
+            description: >-
+              The {{ $labels.operationName }} operation has had a p95
+              response time above 2s for 15 minutes. This usually means an
+              upstream fan-out (one request per organization, project, or
+              user) is serializing instead of running concurrently.
+            runbook_url: "https://github.com/milo-os/graphql-gateway/blob/main/docs/runbooks/slow-operations.md"

--- a/config/components/observability/dashboards/grafana/graphql-gateway.json
+++ b/config/components/observability/dashboards/grafana/graphql-gateway.json
@@ -1430,6 +1430,188 @@
       ],
       "title": "Execute phase",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Operation Latency",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "p95 request duration broken out by GraphQL operationName. Aggregate dashboards above can hide a single slow operation - use this to catch a regression in one query without hand-querying the metrics backend.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 300000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "last"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by(le, operationName) (rate(graphql_envelop_request_duration_bucket[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "{{operationName}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P95 request duration by operation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Average request duration per operation over the selected range. Sorted descending so the slowest operation is always on top.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "id": 17,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by(operationName) (rate(graphql_envelop_request_duration_sum[$__rate_interval])) / sum by(operationName) (rate(graphql_envelop_request_duration_count[$__rate_interval]))",
+          "instant": true,
+          "legendFormat": "{{operationName}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Average request duration by operation",
+      "type": "bargauge"
     }
   ],
   "refresh": "",

--- a/config/components/observability/kustomization.yaml
+++ b/config/components/observability/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 
   # Alerting rules
   - alerts/subgraph-errors.yaml
+  - alerts/slow-operations.yaml

--- a/docs/runbooks/slow-operations.md
+++ b/docs/runbooks/slow-operations.md
@@ -1,0 +1,74 @@
+# GraphQLGatewaySlowOperation
+
+## Alert description
+
+A single GraphQL operation (identified by the `operationName` label) has a
+p95 response time above 2s, sustained for 15 minutes. This fires per
+operation, so the alert tells you exactly which query is slow rather than
+an aggregate gateway-wide number.
+
+## Impact
+
+Users of the affected operation see slow page loads or spinners. Other
+operations are typically unaffected unless the slow one is exhausting a
+shared resource (connection pool, event loop).
+
+## Investigation
+
+### 1. Confirm which operation and how bad
+
+```promql
+histogram_quantile(0.95, sum by (le, operationName) (rate(graphql_envelop_request_duration_bucket[10m])))
+```
+
+Or use the "P95 request duration by operation" / "Average request duration
+by operation" panels on the Hive Gateway dashboard.
+
+### 2. Check for a per-item fan-out
+
+Most slow operations in this gateway come from resolving a list and then
+firing one upstream request per item (per organization, per project, per
+user) instead of batching. Look at fetch volume and duration by URL for the
+affected window:
+
+```promql
+topk(20, sum by (url) (rate(graphql_gateway_fetch_duration_count[10m])))
+```
+
+Many distinct URLs that differ only by an ID (org name, project name, user
+ID) landing in the same short window is the fan-out signature. Compare
+`graphql_gateway_subgraph_execute_duration_sum` for the affected pod against
+the sum of the individual fetch durations in that window - if they're close,
+the fan-out is running sequentially rather than concurrently.
+
+### 3. Check list size
+
+A large organization or project list will always take longer than a small
+one, even with an efficient resolver - more upstream calls, more relative
+latency. This isn't a bug by itself, but it changes how much headroom the
+alert threshold has for that customer.
+
+### 4. Check `src/gateway/graphql/resolvers/organizations.ts`
+
+This is where the `Organizations` and `Projects` operations are resolved.
+See [#46](https://github.com/milo-os/graphql-gateway/issues/46) for a
+description of the specific patterns found there: a sequential await
+between two independent enrichment stages in `enrichProjects()`, and
+per-item `Organization.projects`/`Organization.members` resolvers with no
+batching across siblings in a list.
+
+## Resolution
+
+- If the cause matches the patterns in #46, see that issue for the
+  suggested fix (parallelize the enrichment stages, add batching for the
+  per-item resolvers).
+- If it's simply a large org/project list, no action needed beyond
+  confirming the alert threshold still makes sense.
+
+## Metric
+
+```promql
+histogram_quantile(0.95, sum by (le, operationName) (rate(graphql_envelop_request_duration_bucket[$__rate_interval])))
+```
+
+Labels: `operationName`, `operationType`, `pod`


### PR DESCRIPTION
## Summary

While investigating #46 (Organizations/Projects list queries running 10-30x slower than a single Organization lookup), I couldn't find any panel or alert that would have surfaced it. Every dashboard panel aggregates across all operations, so a single slow query hides inside the average.

This adds:

- A "P95 request duration by operation" timeseries and an "Average request duration by operation" bar gauge, both grouped by `operationName`, on the Hive Gateway dashboard
- A `GraphQLGatewaySlowOperation` alert that fires when any operation's p95 exceeds 2s for 15 minutes
- A runbook (`docs/runbooks/slow-operations.md`) covering how to tell a per-item fan-out from a genuinely large org/project list

Follows the same alerts + runbook pattern as #19 (subgraph errors).

## Test plan

- [x] `kustomize build config/components/observability` renders both VMRules and the dashboard ConfigMap without error
- [x] Dashboard JSON validated with `python3 -m json.tool`
- [ ] Alert expression evaluated against live staging VictoriaMetrics data
- [ ] Dashboard panels checked in a running Grafana instance