### PR TITLE
fix: parallelize org and billing enrichment in enrichProjects

### DIFF
--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -1072,6 +1072,87 @@ describe('Query.projects', () => {
   })
 })
 
+describe('enrichProjects concurrency (via Query.projects)', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  const deferred = <T,>() => {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((r) => {
+      resolve = r
+    })
+    return { promise, resolve }
+  }
+
+  // Lets pending promise chains (fetch -> .json() -> Promise.all setup) settle
+  // without relying on a fixed microtask count.
+  const flush = async (times = 5) => {
+    for (let i = 0; i < times; i++) await new Promise((r) => setImmediate(r))
+  }
+
+  it('dispatches the org fetch and both billing fetches before any of them resolve', async () => {
+    const callOrder: string[] = []
+    const org = deferred<Response>()
+    const bindings = deferred<Response>()
+    const accounts = deferred<Response>()
+
+    fetchSpy = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      if (url.includes('/billingaccountbindings')) {
+        callOrder.push('bindings')
+        return bindings.promise
+      }
+      if (url.includes('/billingaccounts')) {
+        callOrder.push('accounts')
+        return accounts.promise
+      }
+      if (/\/organizations\/[^/?]+$/.test(url)) {
+        callOrder.push('org')
+        return org.promise
+      }
+      if (url.includes('/projects')) {
+        return Promise.resolve(
+          jsonResponse({
+            items: [
+              { metadata: { name: 'proj-a', annotations: {} }, spec: { ownerRef: { name: 'acme' } } },
+            ],
+            metadata: {},
+          })
+        )
+      }
+      return Promise.resolve(jsonResponse({ items: [] }))
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const resultPromise = (
+      additionalResolvers.Query!.projects as (
+        r: null,
+        a: object,
+        c: ReturnType<typeof ctx>
+      ) => Promise<{ items: unknown[] }>
+    )(null, {}, ctx())
+
+    await flush()
+
+    // If the org stage were still awaited to completion before the billing
+    // stage starts (the previous, sequential behavior), only 'org' would be
+    // in callOrder at this point. Seeing all three proves both stages were
+    // dispatched up front.
+    expect(callOrder.sort()).toEqual(['accounts', 'bindings', 'org'])
+
+    org.resolve(acmeOrganization())
+    bindings.resolve(jsonResponse({ items: [] }))
+    accounts.resolve(jsonResponse({ items: [] }))
+
+    const result = await resultPromise
+    expect(result.items).toHaveLength(1)
+  })
+})
+
 describe('Query.project', () => {
   let fetchSpy: ReturnType<typeof vi.fn>
 

--- a/src/gateway/graphql/resolvers/organizations.ts
+++ b/src/gateway/graphql/resolvers/organizations.ts
@@ -267,21 +267,24 @@ async function resolveOrganizationFields(
 }
 
 /**
- * Per owning-org: load billing bindings + accounts, then mark projects that have
- * an Active binding to an account with a default payment method.
+ * Per owning-org: load billing bindings + accounts, then work out which
+ * projects have an Active binding to an account with a default payment
+ * method.
  *
  * Failures are swallowed per-org so a single inaccessible billing namespace
- * never fails the whole project list.
+ * never fails the whole project list. Only depends on each project's
+ * `organizationName`, not on org display/company enrichment, so it can run
+ * concurrently with {@link resolveOrganizationFields} rather than after it.
  */
 async function resolveBillingFields(
   projects: MappedProject[],
   headers: Record<string, string>
-): Promise<MappedProject[]> {
-  if (projects.length === 0) return projects
+): Promise<Map<string, BillingEnrichment>> {
+  const billingByProject = new Map<string, BillingEnrichment>()
+  if (projects.length === 0) return billingByProject
 
   const fetchFn = getOriginalFetch()
   const uniqueOrgs = [...new Set(projects.map((p) => p.organizationName).filter(Boolean))]
-  const billingByProject = new Map<string, BillingEnrichment>()
 
   await Promise.all(
     uniqueOrgs.map(async (orgName) => {
@@ -345,7 +348,29 @@ async function resolveBillingFields(
     })
   )
 
-  return projects.map((project) => {
+  return billingByProject
+}
+
+/**
+ * Org display/company + billing payment status for a project list page.
+ *
+ * The two enrichment stages read disjoint upstream data (org display/company
+ * info vs. billing bindings/accounts) and neither depends on the other's
+ * result, so they run concurrently instead of one after the other.
+ */
+async function enrichProjects(
+  projects: MappedProject[],
+  headers: Record<string, string>
+): Promise<MappedProject[]> {
+  const [orgs, billingByProject] = await Promise.all([
+    resolveOrganizationFields(
+      projects.map((item) => item.organizationName),
+      headers
+    ),
+    resolveBillingFields(projects, headers),
+  ])
+
+  return attachOrganizationFields(projects, orgs).map((project) => {
     const billing = billingByProject.get(project.name)
     return {
       ...project,
@@ -353,18 +378,6 @@ async function resolveBillingFields(
       billingAccountName: billing?.billingAccountName ?? null,
     }
   })
-}
-
-/** Org display/company + billing payment status for a project list page. */
-async function enrichProjects(
-  projects: MappedProject[],
-  headers: Record<string, string>
-): Promise<MappedProject[]> {
-  const orgs = await resolveOrganizationFields(
-    projects.map((item) => item.organizationName),
-    headers
-  )
-  return resolveBillingFields(attachOrganizationFields(projects, orgs), headers)
 }
 
 function organizationsURL(params: { name?: string; limit?: number; cursor?: string } = {}) {


### PR DESCRIPTION
## Summary

Part of #46. `enrichProjects()` (used by `Query.projects`, `Query.project`, and `Organization.projects`) fully awaited `resolveOrganizationFields()` before starting `resolveBillingFields()`, even though billing enrichment only reads `project.organizationName`, which is available before either stage runs. Neither stage depends on the other's output, so they now run concurrently via `Promise.all`.

## What this does and doesn't fix

I also checked whether the unbatched per-item `Organization.members`/`Organization.projects` resolvers (the other half of #46) are adding serial latency across sibling organizations in a list. They aren't: `plugin.ts` routes locally-resolved operations through graphql-js's default `execute()`, which resolves list-item sibling fields concurrently already. So that part of #46 turned out not to be a live bug, just something worth confirming rather than assuming. This PR only addresses the sequential-await bug, which is real and independently worth fixing.

## Benchmark

Ran the actual `Query.projects` resolver (before and after this change) against a mock upstream with delays drawn from real fetch durations recorded in staging (`graphql_gateway_fetch_duration_sum`, 30-551ms), for project lists spanning 5/10/20 distinct organizations:

| orgs | before (sequential) | after (parallel) | improvement |
|---|---|---|---|
| 5 | 874ms | 555ms | 36% |
| 10 | 1107ms | 553ms | 50% |
| 20 | 1106ms | 554ms | 50% |

"After" plateaus near the single slowest upstream call once org count grows, instead of stacking the two stages on top of each other. Benchmark script isn't included in this PR since it duplicates the pre-fix resolver as a comparison baseline (not something worth keeping in the tree). Happy to share it if useful for review.

## Test plan

- [x] `bun run test`: 69 tests pass, including a new regression test asserting the org fetch and both billing fetches are dispatched before either resolves (fails against the pre-fix code, confirmed by temporarily reverting)
- [x] `bun run lint` and `tsc --noEmit` clean
- [x] Manual benchmark against real recorded latencies (see above)
