### PR TITLE
feat(contacts): expose visibility, status & joined date on enriched contact groups

### DIFF
--- a/src/gateway/graphql/resolvers/contacts.ts
+++ b/src/gateway/graphql/resolvers/contacts.ts
@@ -3,11 +3,20 @@ import { log } from '@/shared/utils'
 import { type ResolverContext, getHeader, DESCRIPTION_ANNOTATION } from './common'
 
 interface UpstreamContactGroupMembership {
-  metadata?: { name?: string }
+  metadata?: { name?: string; creationTimestamp?: string }
   spec?: {
     contactRef?: { name?: string; namespace?: string }
     contactGroupRef?: { name?: string; namespace?: string }
   }
+}
+
+interface UpstreamCondition {
+  type?: string
+  status?: string
+  reason?: string
+  message?: string
+  lastTransitionTime?: string
+  observedGeneration?: number
 }
 
 interface UpstreamContactGroupMembershipList {
@@ -22,7 +31,8 @@ interface UpstreamContact {
 
 interface UpstreamContactGroup {
   metadata?: { name?: string; namespace?: string; annotations?: Record<string, string> }
-  spec?: { displayName?: string }
+  spec?: { displayName?: string; visibility?: string }
+  status?: { conditions?: UpstreamCondition[] }
 }
 
 function mapContact(contact: UpstreamContact) {
@@ -41,6 +51,19 @@ function mapContactGroup(group: UpstreamContactGroup) {
     name: group.metadata?.name ?? '',
     namespace: group.metadata?.namespace ?? '',
     displayName: group.spec?.displayName ?? null,
+    visibility: group.spec?.visibility ?? null,
+    status: group.status
+      ? {
+          conditions: (group.status.conditions ?? []).map((c) => ({
+            type: c.type ?? '',
+            status: c.status ?? '',
+            reason: c.reason ?? null,
+            message: c.message ?? null,
+            lastTransitionTime: c.lastTransitionTime ?? null,
+            observedGeneration: c.observedGeneration ?? null,
+          })),
+        }
+      : null,
   }
 }
 
@@ -173,6 +196,7 @@ export const contactsResolvers = {
             const key = ref?.namespace && ref.name ? `${ref.namespace}/${ref.name}` : ''
             return {
               name: m.metadata?.name ?? '',
+              creationTimestamp: m.metadata?.creationTimestamp ?? null,
               contactGroupRef: { name: ref?.name ?? '', namespace: ref?.namespace ?? '' },
               contactGroup: key ? (groupMap.get(key) ?? null) : null,
             }

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -64,10 +64,28 @@ export const additionalTypeDefs = /* GraphQL */ `
     displayName: String
   }
 
+  "A single Kubernetes-style status condition on a ContactGroup."
+  type ContactGroupCondition {
+    type: String!
+    status: String!
+    reason: String
+    message: String
+    lastTransitionTime: String
+    observedGeneration: Int
+  }
+
+  type EnrichedContactGroupStatus {
+    conditions: [ContactGroupCondition!]
+  }
+
   type EnrichedContactGroup {
     name: String!
     namespace: String!
     displayName: String
+    "Whether the group allows opt-in/opt-out membership: 'public' or 'private'."
+    visibility: String
+    "Observed status of the ContactGroup (Ready condition, provider sync)."
+    status: EnrichedContactGroupStatus
   }
 
   type ContactGroupMembershipEnriched {
@@ -81,6 +99,8 @@ export const additionalTypeDefs = /* GraphQL */ `
   type ContactMembershipEnriched {
     "metadata.name of the ContactGroupMembership resource."
     name: String!
+    "When the contact joined the group (membership metadata.creationTimestamp)."
+    creationTimestamp: String
     contactGroupRef: ContactRef!
     "Full ContactGroup data, null if lookup failed."
     contactGroup: EnrichedContactGroup


### PR DESCRIPTION
## Problem

In staff-portal's contact **groups list** (a contact's groups), the `visibility`, `status`, and joined-date columns don't match the group **detail** view. Root cause: `contactMembershipsWithGroups` returns an `EnrichedContactGroup` that only carries `displayName`, so the client defaults `visibility` to `"public"`, renders an empty status, and has no join date — while the detail page reads the real `ContactGroup` resource.

## Change

The resolver **already fetches the full `ContactGroup`** (to get `displayName`) — it just discarded everything else. This projects the missing fields, so there are **no extra upstream calls**.

- `EnrichedContactGroup`: add `visibility` and `status { conditions[] }`
- `ContactMembershipEnriched`: add `creationTimestamp` (when the contact joined the group)
- `mapContactGroup` projects `spec.visibility` + `status.conditions` from the already-fetched resource; the membership mapping carries `metadata.creationTimestamp`
- Added `ContactGroupCondition` / `EnrichedContactGroupStatus` types matching the k8s condition shape the UI consumes

## Testing

- `tsc --noEmit` clean, `eslint` clean, `build` clean
- `vitest run` — 69/69 pass

## Follow-up (staff-portal)

Once this is live: regen the GraphQL client and select/map the new fields in `contact-membership.api.ts`; the list columns already read them. Tracked separately.