### PR TITLE
chore: Route gateway alerts to their owning team

### DIFF
--- a/config/components/observability/alerts/slow-operations.yaml
+++ b/config/components/observability/alerts/slow-operations.yaml
@@ -12,6 +12,8 @@ spec:
           for: 15m
           labels:
             severity: warning
+            service: graphql-gateway
+            team: portals
           annotations:
             summary: >-
               GraphQL operation {{ $labels.operationName }} has a p95

--- a/config/components/observability/alerts/subgraph-errors.yaml
+++ b/config/components/observability/alerts/subgraph-errors.yaml
@@ -12,6 +12,8 @@ spec:
           for: 5m
           labels:
             severity: warning
+            service: graphql-gateway
+            team: portals
           annotations:
             summary: >-
               GraphQL gateway subgraph {{ $labels.subgraphName }} has
@@ -28,6 +30,8 @@ spec:
           for: 10m
           labels:
             severity: critical
+            service: graphql-gateway
+            team: portals
           annotations:
             summary: >-
               GraphQL gateway subgraph {{ $labels.subgraphName }} has


### PR DESCRIPTION
## Summary

An alert from this service reached on-call with nothing but a severity on it, so it landed in one shared channel with no way to tell whose it was. Every alert this service ships now carries the service it came from and the team that owns it, so routing and attribution can send it to the right people.

The owning team is portals, matching the service catalog.

## Test plan

- [ ] Rendered rules carry the owning team and service on every alert
- [ ] Thresholds, expressions, and firing behavior are unchanged

Related to datum-cloud/infra#3983
