### PR TITLE
feat: Expose project deletion GraphQL fields

### DIFF
--- a/src/gateway/graphql/resolvers.test.ts
+++ b/src/gateway/graphql/resolvers.test.ts
@@ -1056,6 +1056,62 @@ describe('Query.projects', () => {
       organizationBusinessName: 'Acme LLC',
       hasActiveBillingAccount: true,
       billingAccountName: 'ba-1',
+      deletionTimestamp: null,
+      resourceCleanupMessage: null,
+    })
+  })
+
+  it('maps deletionTimestamp and ResourceCleanup message on a deleting project', async () => {
+    fetchSpy = projectOrgRoutedFetch({
+      projectsList: jsonResponse({
+        items: [
+          {
+            metadata: {
+              name: 'proj-deleting',
+              deletionTimestamp: '2026-08-20T10:00:00Z',
+              annotations: {},
+            },
+            spec: { ownerRef: { name: 'acme' } },
+            status: {
+              conditions: [
+                { type: 'Ready', status: 'True' },
+                {
+                  type: 'ResourceCleanup',
+                  status: 'True',
+                  message:
+                    'Waiting for project resources to be removed: configmaps "default/billing-export-job" (finalizers: billing.example.com/drain-pending)',
+                },
+              ],
+            },
+          },
+        ],
+        metadata: {},
+      }),
+      organizations: { acme: acmeOrganization() },
+      ...acmeBillingWithPayment(),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const result = await (
+      additionalResolvers.Query!.projects as (
+        r: null,
+        a: object,
+        c: ReturnType<typeof ctx>
+      ) => Promise<{
+        items: {
+          name: string
+          state: string | null
+          deletionTimestamp: string | null
+          resourceCleanupMessage: string | null
+        }[]
+      }>
+    )(null, {}, ctx())
+    expect(result.items[0]).toMatchObject({
+      name: 'proj-deleting',
+      state: 'True',
+      deletionTimestamp: '2026-08-20T10:00:00Z',
+      resourceCleanupMessage:
+        'Waiting for project resources to be removed: configmaps "default/billing-export-job" (finalizers: billing.example.com/drain-pending)',
     })
   })
 

--- a/src/gateway/graphql/resolvers/organizations.ts
+++ b/src/gateway/graphql/resolvers/organizations.ts
@@ -35,10 +35,11 @@ interface UpstreamProjectFull {
   metadata?: {
     name?: string
     creationTimestamp?: string
+    deletionTimestamp?: string
     annotations?: Record<string, string>
   }
   spec?: { ownerRef?: { name?: string; kind?: string } }
-  status?: { conditions?: Array<{ type?: string; status?: string }> }
+  status?: { conditions?: Array<{ type?: string; status?: string; message?: string }> }
 }
 
 interface UpstreamProjectList {
@@ -124,6 +125,8 @@ export interface MappedProject {
   billingAccountName: string | null
   createdAt: string | null
   state: string | null
+  deletionTimestamp: string | null
+  resourceCleanupMessage: string | null
 }
 
 type OrgEnrichment = {
@@ -191,6 +194,7 @@ function mapProjectFull(raw: UpstreamProjectFull): MappedProject {
     raw.metadata?.name ||
     ''
   const readyCondition = raw.status?.conditions?.find((c) => c.type === 'Ready')
+  const cleanupCondition = raw.status?.conditions?.find((c) => c.type === 'ResourceCleanup')
   const organizationName = raw.spec?.ownerRef?.name ?? ''
   return {
     name: raw.metadata?.name ?? '',
@@ -203,6 +207,8 @@ function mapProjectFull(raw: UpstreamProjectFull): MappedProject {
     billingAccountName: null,
     createdAt: raw.metadata?.creationTimestamp ?? null,
     state: readyCondition?.status ?? null,
+    deletionTimestamp: raw.metadata?.deletionTimestamp ?? null,
+    resourceCleanupMessage: cleanupCondition?.message?.trim() || null,
   }
 }
 

--- a/src/gateway/graphql/typeDefs.ts
+++ b/src/gateway/graphql/typeDefs.ts
@@ -230,6 +230,10 @@ export const additionalTypeDefs = /* GraphQL */ `
     createdAt: String
     "Status of the Ready condition."
     state: String
+    "metadata.deletionTimestamp — set while the project is terminating."
+    deletionTimestamp: String
+    "Unparsed ResourceCleanup condition message naming what deletion is waiting on."
+    resourceCleanupMessage: String
   }
 
   type ProjectList {


### PR DESCRIPTION
## Summary

Staff portal's global and org project tables are GraphQL-backed. Today's `state` field is the Ready condition, which stays True during drain, so a deleting project looks the same as a healthy one.

This passes through two fields that already exist on the Milo Project object:

- `deletionTimestamp`: `metadata.deletionTimestamp` (null when the project is not terminating)
- `resourceCleanupMessage`: the ResourceCleanup condition message, unparsed (null when there is no message)

Terminating projects stay in lists. Milo already returns them; the gateway does not drop them. The cleanup message is left as text for staff portal to display, not parsed into resource rows.

These fields are additive. Existing queries that omit them are unchanged.

## Test plan

- [x] `bun run test -- src/gateway/graphql/resolvers.test.ts`: 56 tests pass
- [x] Healthy project maps both new fields to null
- [x] Deleting project with Ready=True maps `deletionTimestamp` and the ResourceCleanup message
- [ ] After deploy, staff-portal queries that select these fields succeed

## Notes for reviewers

Unknown GraphQL fields fail the query, so this needs to land before the staff-portal list changes for [staff-portal#618](https://github.com/datum-cloud/staff-portal/issues/618).

Related to [milo#752](https://github.com/milo-os/milo/pull/752).